### PR TITLE
merge in data documentation, data downloader updates

### DIFF
--- a/explorer/meta/csvFiles.js
+++ b/explorer/meta/csvFiles.js
@@ -1,432 +1,98 @@
 export const csvFiles = [
-    {
-      "file": "Access01_C",
-      "topic": "Health Variables",
-      "scale": "C"
-    },
-    {
-      "file": "Access01_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access01_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access02_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access02_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access03_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access03_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access04_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access04_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access05_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access05_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access06_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access06_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "Access07_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Access07_Z",
-      "topic": "Health Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "BE01_C",
-      "topic": "Physical Environment Variables",
-      "scale": "C"
-    },
-    {
-      "file": "BE01_S",
-      "topic": "Physical Environment Variables",
-      "scale": "S"
-    },
-    {
-      "file": "BE01_T",
-      "topic": "Physical Environment Variables",
-      "scale": "T"
-    },
-    {
-      "file": "BE01_Z",
-      "topic": "Physical Environment Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "BE02_RUCA_C",
-      "topic": "Physical Environment Variables",
-      "scale": "C"
-    },
-    {
-      "file": "BE02_RUCA_T",
-      "topic": "Physical Environment Variables",
-      "scale": "T"
-    },
-    {
-      "file": "BE02_RUCA_Z",
-      "topic": "Physical Environment Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "BE03_C",
-      "topic": "Physical Environment Variables",
-      "scale": "C"
-    },
-    {
-      "file": "BE03_S",
-      "topic": "Physical Environment Variables",
-      "scale": "S"
-    },
-    {
-      "file": "BE03_T",
-      "topic": "Physical Environment Variables",
-      "scale": "T"
-    },
-    {
-      "file": "BE03_Z",
-      "topic": "Physical Environment Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "BE04_C",
-      "topic": "Physical Environment Variables",
-      "scale": "C"
-    },
-    {
-      "file": "BE05_C",
-      "topic": "Physical Environment Variables",
-      "scale": "C"
-    },
-    {
-      "file": "BE06_NDVI_T",
-      "topic": "Physical Environment Variables",
-      "scale": "T"
-    },
-    {
-      "file": "COVID01_C",
-      "topic": "COVID Variables",
-      "scale": "C"
-    },
-    {
-      "file": "COVID01_S",
-      "topic": "COVID Variables",
-      "scale": "S"
-    },
-    {
-      "file": "COVID02_C",
-      "topic": "COVID Variables",
-      "scale": "C"
-    },
-    {
-      "file": "COVID02_S",
-      "topic": "COVID Variables",
-      "scale": "S"
-    },
-    {
-      "file": "COVID03_C",
-      "topic": "COVID Variables",
-      "scale": "C"
-    },
-    {
-      "file": "COVID03_S",
-      "topic": "COVID Variables",
-      "scale": "S"
-    },
-    {
-      "file": "COVID04_C",
-      "topic": "COVID Variables",
-      "scale": "C"
-    },
-    {
-      "file": "COVID04_S",
-      "topic": "COVID Variables",
-      "scale": "S"
-    },
-    {
-      "file": "DS01_C",
-      "topic": "Demographic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "DS01_S",
-      "topic": "Demographic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "DS01_T",
-      "topic": "Demographic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "DS01_Z",
-      "topic": "Demographic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "DS02_T",
-      "topic": "Demographic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "DS03_C",
-      "topic": "Demographic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "DS03_T",
-      "topic": "Demographic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "DS03_Z",
-      "topic": "Demographic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "DS04_C",
-      "topic": "Demographic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "DS04_S",
-      "topic": "Demographic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "DS04_T",
-      "topic": "Demographic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "DS04_Z",
-      "topic": "Demographic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "DS05_C",
-      "topic": "Demographic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "DS05_S",
-      "topic": "Demographic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "DS05_T",
-      "topic": "Demographic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "DS05_Z",
-      "topic": "Demographic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "EC01_2018_C",
-      "topic": "Economic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "EC01_2018_S",
-      "topic": "Economic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "EC01_2018_T",
-      "topic": "Economic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "EC01_2018_Z",
-      "topic": "Economic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "EC02_C",
-      "topic": "Economic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "EC02_S",
-      "topic": "Economic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "EC02_T",
-      "topic": "Economic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "EC02_Z",
-      "topic": "Economic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "EC03_2018_C",
-      "topic": "Economic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "EC03_2018_S",
-      "topic": "Economic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "EC03_2018_T",
-      "topic": "Economic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "EC03_2018_Z",
-      "topic": "Economic Variables",
-      "scale": "Z"
-    },
-    {
-      "file": "EC04_C",
-      "topic": "Economic Variables",
-      "scale": "C"
-    },
-    {
-      "file": "EC04_S",
-      "topic": "Economic Variables",
-      "scale": "S"
-    },
-    {
-      "file": "EC04_T",
-      "topic": "Economic Variables",
-      "scale": "T"
-    },
-    {
-      "file": "Health01_C",
-      "topic": "Health Variables",
-      "scale": "C"
-    },
-    {
-      "file": "Health01_S",
-      "topic": "Health Variables",
-      "scale": "S"
-    },
-    {
-      "file": "Health02_C_Mortality",
-      "topic": "Health Variables",
-      "scale": "C"
-    },
-    {
-      "file": "Health02_S_Mortality",
-      "topic": "Health Variables",
-      "scale": "S"
-    },
-    {
-      "file": "Health02_S_Prevalence",
-      "topic": "Health Variables",
-      "scale": "S"
-    },
-    {
-      "file": "Health03_C",
-      "topic": "Health Variables",
-      "scale": "C"
-    },
-    {
-      "file": "Health03_S",
-      "topic": "Health Variables",
-      "scale": "S"
-    },
-    {
-      "file": "Health03_T",
-      "topic": "Health Variables",
-      "scale": "T"
-    },
-    {
-      "file": "PS01_2016_C",
-      "topic": "Policy Variables",
-      "scale": "C"
-    },
-    {
-      "file": "PS02_2017_C",
-      "topic": "Policy Variables",
-      "scale": "C"
-    },
-    {
-      "file": "PS03_2017_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS04_2018_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS05_2017_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS06_2019_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS07_2018_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS08_2019_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS09_2017_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    },
-    {
-      "file": "PS11_S",
-      "topic": "Policy Variables",
-      "scale": "S"
-    }
+  {
+    "file": "C_Latest",
+    "folder": "full_tables/",
+    "year": "Latest",
+    "scale": "C",
+  },
+  {
+    "file": "C_2010",
+    "folder": "full_tables/",
+    "year": "2010",
+    "scale": "C"
+  },
+  {
+    "file": "C_2000",
+    "folder": "full_tables/",
+    "year": "2000",
+    "scale": "C"
+  },
+  {
+    "file": "C_1990",
+    "folder": "full_tables/",
+    "year": "1990",
+    "scale": "C"
+  },
+  {
+    "file": "C_1980",
+    "folder": "full_tables/",
+    "year": "1980",
+    "scale": "C"
+  },
+  {
+    "file": "S_Latest",
+    "folder": "full_tables/",
+    "year": "Latest",
+    "scale": "S",
+  },
+  {
+    "file": "S_2010",
+    "folder": "full_tables/",
+    "year": "2010",
+    "scale": "S"
+  },
+  {
+    "file": "S_2000",
+    "folder": "full_tables/",
+    "year": "2000",
+    "scale": "S"
+  },
+  {
+    "file": "S_1990",
+    "folder": "full_tables/",
+    "year": "1990",
+    "scale": "S"
+  },
+  {
+    "file": "S_1980",
+    "folder": "full_tables/",
+    "year": "1980",
+    "scale": "S"
+  },
+  {
+    "file": "T_Latest",
+    "folder": "full_tables/",
+    "year": "Latest",
+    "scale": "T"
+  },
+  {
+    "file": "T_2010",
+    "folder": "full_tables/",
+    "year": "2010",
+    "scale": "T"
+  },
+  {
+    "file": "T_2000",
+    "folder": "full_tables/",
+    "year": "2000",
+    "scale": "T"
+  },
+  {
+    "file": "T_1990",
+    "folder": "full_tables/",
+    "year": "1990",
+    "scale": "T"
+  },
+  {
+    "file": "T_1980",
+    "folder": "full_tables/",
+    "year": "1980",
+    "scale": "T"
+  },
+  {
+    "file": "Z_Latest",
+    "folder": "full_tables/",
+    "year": "Latest",
+    "scale": "Z"
+  }
   ]

--- a/explorer/meta/variables.js
+++ b/explorer/meta/variables.js
@@ -148,7 +148,7 @@ export const variables = {
     },
     {
       'Variable Proxy': 'HepC prevalence and mortality',
-      Source: 'HepVu, 2017',
+      Source: 'HepVu 2017',
       Metadata: 'Health02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan//data_final/metadata/HepC.md">Hepatitis C</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'Health02 / ',

--- a/explorer/meta/variables.js
+++ b/explorer/meta/variables.js
@@ -11,15 +11,25 @@ export const variables = {
       'Variable Construct': 'Geographic Boundaries'
     },
     {
-      'Variable Proxy': 'County, Census Tract, Zip Code Tract Area (ZCTA)',
-      Source: 'HUD’s Office of Policy Development and Research (PD&R)',
-      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/crosswalk.md">Crosswalk Files</a>',
-      'Spatial Scale': 'County, Tract, Zip',
+      'Variable Proxy': 'State, County, Census Tract, Zip Code Tract Area (ZCTA)',
+      Source: 'US Census, 2010',
+      Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/GeographicBoundaries_2018.md">Geographic Boundaries</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: '',
-      markdownText: 'Crosswalk Files',
-      markdown: 'crosswalk',
-      'Variable Construct': 'Crosswalk files'
-    }
+      markdownText: 'Geographic Boundaries',
+      markdown: 'GeographicBoundaries_2010',
+      'Variable Construct': 'Geographic Boundaries'
+    }//,
+    // {
+    //   'Variable Proxy': 'County, Census Tract, Zip Code Tract Area (ZCTA)',
+    //   Source: 'HUD’s Office of Policy Development and Research (PD&R)',
+    //   Metadata: '<a href="https://github.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/crosswalk.md">Crosswalk Files</a>',
+    //   'Spatial Scale': 'County, Tract, Zip',
+    //   markdownPrefix: '',
+    //   markdownText: 'Crosswalk Files',
+    //   markdown: 'crosswalk',
+    //   'Variable Construct': 'Crosswalk files'
+    // }
   ],
   'Policy Variables': [
     {
@@ -75,23 +85,24 @@ export const variables = {
     {
       'Variable Proxy': 'Total Medicaid spending',
       Source: 'KFF, 2019',
-      Metadata: 'PS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExp_2019.md">MedExp</a>',
+      Metadata: 'PS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExp_2018_19.md">MedExp</a>',
       'Spatial Scale': 'State',
       markdownPrefix: 'PS06 / ',
       markdownText: 'MedExp',
-      markdown: 'MedExp_2019',
+      markdown: 'MedExp_2018_19',
       'Variable Construct': 'Medicaid Expenditure'
     },
-    {
-      'Variable Proxy': 'Spending for adults who have enrolled through Medicaid expansion',
-      Source: 'KFF, 2018',
-      Metadata: 'PS07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExpan_2018.md">MedExpan</a>',
-      'Spatial Scale': 'State',
-      markdownPrefix: 'PS07 / ',
-      markdownText: 'MedExpan',
-      markdown: 'MedExpan_2018',
-      'Variable Construct': 'Medicaid Expansion'
-    },
+    // This doesn't appear in the current suite of metadata files.
+    // {
+    //   'Variable Proxy': 'Spending for adults who have enrolled through Medicaid expansion',
+    //   Source: 'KFF, 2018',
+    //   Metadata: 'PS07 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/MedExpan_2018.md">MedExpan</a>',
+    //   'Spatial Scale': 'State',
+    //   markdownPrefix: 'PS07 / ',
+    //   markdownText: 'MedExpan',
+    //   markdown: 'MedExpan_2018',
+    //   'Variable Construct': 'Medicaid Expansion'
+    // },
     {
       'Variable Proxy': 'Laws clarifying legal status for syringe exchange, distribution, and possession programs',
       Source: 'LawAtlas, 2019',
@@ -124,7 +135,7 @@ export const variables = {
     }
   ],
 
-  'Health Variables': [
+  'Outcome Variables': [
     {
       'Variable Proxy': 'Death rate from drug-related causes',
       Source: 'CDC WONDER, 2009-2019',
@@ -138,26 +149,16 @@ export const variables = {
     {
       'Variable Proxy': 'HepC prevalence and mortality',
       Source: 'HepVu, 2017',
-      Metadata: 'Health02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan//data_final/metadata/HepC_rate.md">Hepatitis C</a>',
+      Metadata: 'Health02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan//data_final/metadata/HepC.md">Hepatitis C</a>',
       'Spatial Scale': 'State, County',
       markdownPrefix: 'Health02 / ',
       markdownText: 'Hepatitis C',
-      markdown: 'HepC_rate',
+      markdown: 'HepC',
       'Variable Construct': 'Hepatitis C rates'
     },
     {
-      'Variable Proxy': 'Number of Primary Care and Specialist Physicians',
-      Source: 'Dartmouth Atlas, 2010',
-      Metadata: 'Health03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Health_PCPs.md">Physicians</a>',
-      'Spatial Scale': 'Tract, County, State',
-      markdownPrefix: 'Health03 / ',
-      markdownText: 'Physicians',
-      markdown: 'Health_PCPs',
-      'Variable Construct': 'Physicians'
-    },
-    {
       'Variable Proxy': 'Opioid Prescription Rates',
-      Source: 'HepVu, CDC, 2018-2019',
+      Source: 'HepVu 2020',
       Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
       'Spatial Scale': 'County, State',
       markdownPrefix: 'Health04 / ',
@@ -167,13 +168,311 @@ export const variables = {
     },
     {
       'Variable Proxy': 'Opioid Mortality Rates',
-      Source: 'HepVu, NVSS, 2014-2019',
+      Source: 'HepVu 2020',
       Metadata: 'Health04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/OpioidIndicators.md">Opioid Indicators</a>',
       'Spatial Scale': 'County, State',
       markdownPrefix: 'Health04 / ',
       markdownText: 'Opioid Mortality Rates',
       markdown: 'OpioidIndicators',
       'Variable Construct': 'Opioid Mortality Rates'
+    },
+  ],
+
+  'Social Variables': [
+    {
+      'Variable Proxy': 'Percentages of population defined by categories of race and ethnicity',
+      Source: 'ACS 2018, 5-Year; Census 2010; IPUMS NHGIS',
+      Metadata: 'DS01/ <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Race_Ethnicity_2018.md">Race & Ethnicity Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS01 / ',
+      markdownText: 'Race & Ethnicity Variables',
+      markdown: 'Race_Ethnicity_2018',
+      'Variable Construct': 'Race & Ethnicity'
+    },
+    {
+      'Variable Proxy': 'Age group estimates and percentages of population',
+      Source: 'ACS 2018, 5-Year; Census 2010; IPUMS NHGIS',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Age_2018.md">Age Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS01 / ',
+      markdownText: 'Age Variables',
+      markdown: 'Age_2018',
+      'Variable Construct': 'Age'
+    },
+    {
+      'Variable Proxy': 'Percentage of population with a disability',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; IPUMS NHGIS',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS01 / ',
+      markdownText: 'Other Demographic Variables',
+      markdown: 'Other_Demographic_2018',
+      'Variable Construct': 'Population with a Disability'
+    },
+    {
+      'Variable Proxy': 'Population without a high school degree',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; IPUMS NHGIS',
+      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS01 / ',
+      markdownText: 'Other Demographic Variables',
+      markdown: 'Other_Demographic_2018',
+      'Variable Construct': 'Educational Attainment'
+    },
+    {
+      'Variable Proxy': 'SDOH Neighborhood Typologies',
+      Source: 'Kolak et al, 2020',
+      Metadata: 'DS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SDOH_2014.md">SDOH Typology</a>',
+      'Spatial Scale': 'Tract',
+      markdownPrefix: 'DS02 / ',
+      markdownText: 'SDOH Typology',
+      markdown: 'SDOH_2014',
+      'Variable Construct': 'Social Determinants of Health (SDOH)'
+    },
+    {
+      'Variable Proxy': 'SVI Rankings',
+      Source: 'CDC, 2018',
+      Metadata: 'DS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SVI_2018.md">SVI</a>',
+      'Spatial Scale': 'County, Tract',
+      markdownPrefix: 'DS03 / ',
+      markdownText: 'SVI',
+      markdown: 'SVI_2018',
+      'Variable Construct': 'Social Vulnerability Index (SVI)'
+    },
+    {
+      'Variable Proxy': 'Population as defined by veteran status',
+      Source: 'ACS 2017, 5-Year; ACS 2012, 5-Year',
+      Metadata: 'DS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/VetPop.md">Veteran Population Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS04 / ',
+      markdownText: 'Veteran Population Variables',
+      markdown: 'VetPop',
+      'Variable Construct': 'Veteran Population'
+    },
+    {
+      'Variable Proxy': 'Household types and group quarter populations',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year',
+      Metadata: 'DS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HouseholdType.md">Housing Type Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS05 / ',
+      markdownText: 'Household Type',
+      markdown: 'HouseholdType',
+      'Variable Construct': 'Household Type'
+    },
+    {
+      'Variable Proxy': 'Homelessness as defined by US Homeless Census',
+      Source: 'HUD, 2018',
+      Metadata: 'DS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HomelessPop.md">Homeless Population Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'DS06 / ',
+      markdownText: 'Homeless Population Variables',
+      markdown: 'HomelessPop',
+      'Variable Construct': 'Homeless Population'
+    },
+    {
+      'Variable Proxy': 'US metropolitan areas where black residents experience hypersegregation',
+      Source: 'Massey et al, 2015',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
+      'Spatial Scale': 'County',
+      markdownPrefix: 'BE04 / ',
+      markdownText: 'Community Overlays',
+      markdown: 'Overlay',
+      'Variable Construct': 'Hypersegregated Cities'
+    },
+    {
+      'Variable Proxy': 'US counties where 30% of the population identified as Black or African American',
+      Source: 'US Census, 2000',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
+      'Spatial Scale': 'County',
+      markdownPrefix: 'BE04 / ',
+      markdownText: 'Community Overlays',
+      markdown: 'Overlay',
+      'Variable Construct': 'Southern Black Belt'
+    },
+    {
+      'Variable Proxy': 'Percent area of total land in Native American Reservations',
+      Source: 'US Census, TIGER/Line 2018',
+      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
+      'Spatial Scale': 'County',
+      markdownPrefix: 'BE04 / ',
+      markdownText: 'Community Overlays',
+      markdown: 'Overlay',
+      'Variable Construct': 'Native American Reservations'
+    },
+    {
+      'Variable Proxy': 'Three index measures of segregation: dissimilarity, interaction, isolation',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'BE05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Residential_Seg_Indices.md">Residential Segregation</a>',
+      'Spatial Scale': 'State, County, Zip',
+      markdownPrefix: 'BE05 / ',
+      markdownText: 'Residential Segregation',
+      markdown: 'Residential_Seg_Indices',
+      'Variable Construct': 'Residential Segregation Indices'
+    }
+  ],
+  'Economic Variables': [
+    {
+      'Variable Proxy': 'Percentage of population employed in High Risk of Injury Jobs, Educational Services, Health Care, Retail industries',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'EC01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'EC01 / ',
+      markdownText: 'Jobs by Industry',
+      markdown: 'Job_Categories_byIndustry_2018',
+      'Variable Construct': 'Employment Trends'
+    },
+    {
+      'Variable Proxy': 'Percentage of population employed in Essential Jobs as defined during the COVID-19 pandemic',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'EC02 / ',
+      markdownText: 'Jobs by Industry',
+      markdown: 'Job_Categories_byIndustry_2018',
+      'Variable Construct': 'Essential Workers'
+    },
+    {
+      'Variable Proxy': 'Unemployment rate',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; Social Explorer',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'EC03 / ',
+      markdownText: 'Economic Variables',
+      markdown: 'Economic_2018',
+      'Variable Construct': 'Unemployment Rate'
+    },
+    {
+      'Variable Proxy': 'Percent classified as below poverty level, based on income',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; Social Explorer',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'EC03 / ',
+      markdownText: 'Economic Variables',
+      markdown: 'Economic_2018',
+      'Variable Construct': 'Poverty Rate'
+    },
+    {
+      'Variable Proxy': 'Per capita income in the past 12 months',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; IPUMS NHGIS',
+      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'EC03 / ',
+      markdownText: 'Economic Variables',
+      markdown: 'Economic_2018',
+      'Variable Construct': 'Per Capita Income'
+    },
+    {
+      'Variable Proxy': 'Mortgage foreclosure and severe delinquency rate',
+      Source: 'HUD, 2009',
+      Metadata: 'EC04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/ForeclosureRate.md">Foreclosure Rate</a>',
+      'Spatial Scale': 'State, County, Tract',
+      markdownPrefix: 'EC04 / ',
+      markdownText: 'Foreclosure Rate',
+      markdown: 'ForeclosureRate',
+      'Variable Construct': 'Foreclosure Rate'
+    }
+  ],
+  'Physical Environment Variables': [
+    // We *technically* don't offer this variable
+    // {
+    //   'Variable Proxy': 'Percent occupied units',
+    //   Source: 'ACS 2018, 5-Year',
+    //   Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
+    //   'Spatial Scale': 'State, County, Tract, Zip',
+    //   markdownPrefix: 'BE01 / ',
+    //   markdownText: 'Housing',
+    //   markdown: 'Housing_2018',
+    //   'Variable Construct': 'Housing Occupancy Rate'
+    // },
+    {
+      'Variable Proxy': 'Percent vacant units',
+      Source: 'ACS 2018, 5-Year; ACS 2012, 5-Year; Social Explorer',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE01 / ',
+      markdownText: 'Housing',
+      markdown: 'Housing_2018',
+      'Variable Construct': 'Housing Vacancy Rate'
+    },
+    {
+      'Variable Proxy': 'Percentage of population living in current housing for 20+ years',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE01 / ',
+      markdownText: 'Housing',
+      markdown: 'Housing_2018',
+      'Variable Construct': 'Long Term Occupancy'
+    },
+    {
+      'Variable Proxy': 'Percent of housing units classified as mobile homes',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'BE01 / <a href="/data_final/metadata/Housing_2018.md">Housing</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE01 / ',
+      markdownText: 'Housing',
+      markdown: 'BE01',
+      'Variable Construct': 'Mobile Homes'
+    },
+    {
+      'Variable Proxy': 'Percent of housing units occupied by renters',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE01 / ',
+      markdownText: 'Housing',
+      markdown: 'Housing_2018',
+      'Variable Construct': 'Rental Rates'
+    },
+    {
+      'Variable Proxy': 'Housing units per square mile',
+      Source: 'ACS 2018, 5-Year',
+      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE01 / ',
+      markdownText: 'Housing',
+      markdown: 'Housing_2018',
+      'Variable Construct': 'Housing Unit Density'
+    },
+    {
+      'Variable Proxy': 'Classification of areas as rural, urban or suburban using percent rurality (County)',
+      Source: 'USDA-ERS, 2010',
+      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_County.md">Rural-Urban Classifications (County)</a>',
+      'Spatial Scale': 'County',
+      markdownPrefix: 'BE02 / ',
+      markdownText: 'Rural-Urban Classifications',
+      markdown: 'Rural_Urban_Classification_County',
+      'Variable Construct': 'Urban/Suburban/Rural Classification (County)'
+    },
+    {
+      'Variable Proxy': 'Classification of areas as rural, urban or suburban using RUCA Codes (Tract, Zip)',
+      Source: 'USDA-ERS, 2010',
+      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_T_Z.md">Rural-Urban Classifications (Tract, Zip)</a>',
+      'Spatial Scale': 'Tract, Zip',
+      markdownPrefix: 'BE02 / ',
+      markdownText: 'Rural-Urban Classifications',
+      markdown: 'Rural_Urban_Classification_T_Z',
+      'Variable Construct': 'Urban/Suburban/Rural Classification (Tract, Zip)'
+    },
+    {
+      'Variable Proxy': 'Alcohol outlets per square mile, alcohol outlets per capita',
+      Source: 'InfoGroup, 2018',
+      Metadata: 'BE03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/AlcoholOutlets_2018.md">Alcohol Outlets</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE03 / ',
+      markdownText: 'Alcohol Outlets',
+      markdown: 'AlcoholOutlets_2018',
+      'Variable Construct': 'Alcohol Outlet Density'
+    },
+    {
+      'Variable Proxy': 'Normalized Difference Vegetation Index (NDVI) average value',
+      Source: 'Sentinel-2 MSI, 2018',
+      Metadata: 'BE06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/NDVI.md">NDVI</a>',
+      'Spatial Scale': 'State, County, Tract, Zip',
+      markdownPrefix: 'BE06 / ',
+      markdownText: 'NDVI',
+      markdown: 'NDVI',
+      'Variable Construct': 'NDVI'
     },
     {
       'Variable Proxy': 'Access to MOUDs',
@@ -244,320 +543,32 @@ export const variables = {
       markdownText: 'Access: Opioid Treatment Programs',
       markdown: 'Access_OpioidUseTreatment',
       'Variable Construct': 'Access to Opioid Treatment Programs'
-    }
-  ],
-
-  'Demographic Variables': [
-    {
-      'Variable Proxy': 'Percentages of population defined by categories of race and ethnicity',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01/ <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Race_Ethnicity_2018.md">Race & Ethnicity Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: '',
-      markdownText: 'Race & Ethnicity Variables',
-      markdown: 'Race_Ethnicity_2018',
-      'Variable Construct': 'Race & Ethnicity'
-    },
-    {
-      'Variable Proxy': 'Age group estimates and percentages of population',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Age_2018.md">Age Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS01 / ',
-      markdownText: 'Age Variables',
-      markdown: 'Age_2018',
-      'Variable Construct': 'Age'
-    },
-    {
-      'Variable Proxy': 'Percentage of population with a disability',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS01 / ',
-      markdownText: 'Other Demographic Variables',
-      markdown: 'Other_Demographic_2018',
-      'Variable Construct': 'Population with a Disability'
-    },
-    {
-      'Variable Proxy': 'Population without a high school degree',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'DS01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Other_Demographic_2018.md">Other Demographic Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS01 / ',
-      markdownText: 'Other Demographic Variables',
-      markdown: 'Other_Demographic_2018',
-      'Variable Construct': 'Educational Attainment'
-    },
-    {
-      'Variable Proxy': 'SDOH Neighborhood Typologies',
-      Source: 'Kolak et al, 2020',
-      Metadata: 'DS02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SDOH_2014.md">SDOH Typology</a>',
-      'Spatial Scale': 'Tract',
-      markdownPrefix: 'DS02 / ',
-      markdownText: 'SDOH Typology',
-      markdown: 'SDOH_2014',
-      'Variable Construct': 'Social Determinants of Health (SDOH)'
-    },
-    {
-      'Variable Proxy': 'SVI Rankings',
-      Source: 'CDC, 2018',
-      Metadata: 'DS03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/SVI_2018.md">SVI</a>',
-      'Spatial Scale': 'County, Tract',
-      markdownPrefix: 'DS03 / ',
-      markdownText: 'SVI',
-      markdown: 'SVI_2018',
-      'Variable Construct': 'Social Vulnerability Index (SVI)'
-    },
-    {
-      'Variable Proxy': 'Population as defined by veteran status',
-      Source: 'ACS, 2017 5-year',
-      Metadata: 'DS04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/VetPop.md">Veteran Population Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS04 / ',
-      markdownText: 'Veteran Population Variables',
-      markdown: 'VetPop',
-      'Variable Construct': 'Veteran Population'
-    },
-    {
-      'Variable Proxy': 'Household types and group quarter populations',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'DS05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HouseholdType.md">Housing Type Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS05 / ',
-      markdownText: 'Household Type',
-      markdown: 'HouseholdType',
-      'Variable Construct': 'Household Type'
-    },
-    {
-      'Variable Proxy': 'Homelessness as defined by US Homeless Census',
-      Source: 'HUD, 2018',
-      Metadata: 'DS06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/HomelessPop.md">Homeless Population Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'DS06 / ',
-      markdownText: 'Homeless Population Variables',
-      markdown: 'HomelessPop',
-      'Variable Construct': 'Homeless Population'
-    }
-
-  ],
-  'Economic Variables': [
-    {
-      'Variable Proxy': 'Percentage of population employed in High Risk of Injury Jobs, Educational Services, Health Care, Retail industries',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'EC01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'EC01 / ',
-      markdownText: 'Jobs by Industry',
-      markdown: 'Job_Categories_byIndustry_2018',
-      'Variable Construct': 'Employment Trends'
-    },
-    {
-      'Variable Proxy': 'Percentage of population employed in Essential Jobs as defined during the COVID-19 pandemic (see COVID-19 Variables, below)',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byIndustry_2018.md">Jobs by Industry</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'EC02 / ',
-      markdownText: 'Jobs by Industry',
-      markdown: 'Job_Categories_byIndustry_2018',
-      'Variable Construct': 'Essential Workers'
-    },
-    {
-      'Variable Proxy': 'Unemployment rate',
-      Source: 'ACS, 2014-2018',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'EC03 / ',
-      markdownText: 'Economic Variables',
-      markdown: 'Economic_2018',
-      'Variable Construct': 'Unemployment Rate'
-    },
-    {
-      'Variable Proxy': 'Percent classified as below poverty level, based on income',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'EC03 / ',
-      markdownText: 'Economic Variables',
-      markdown: 'Economic_2018',
-      'Variable Construct': 'Poverty Rate'
-    },
-    {
-      'Variable Proxy': 'Per capita income in the past 12 months',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'EC03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Economic_2018.md">Economic Variables</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'EC03 / ',
-      markdownText: 'Economic Variables',
-      markdown: 'Economic_2018',
-      'Variable Construct': 'Per Capita Income'
-    },
-    {
-      'Variable Proxy': 'Mortgage foreclosure and severe delinquency rate',
-      Source: 'HUD, 2009',
-      Metadata: 'EC04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/ForeclosureRate.md">Foreclosure Rate</a>',
-      'Spatial Scale': 'State, County, Tract',
-      markdownPrefix: 'EC04 / ',
-      markdownText: 'Foreclosure Rate',
-      markdown: 'ForeclosureRate',
-      'Variable Construct': 'Foreclosure Rate'
     },
     {
       'Variable Proxy': 'Percent of households without internet access',
-      Source: 'ACS, 2019 5-year',
+      Source: 'ACS 2019, 5-year',
       Metadata: 'EC05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Internet_2019.md">Internet Access</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC05 / ',
       markdownText: 'Internet Access',
       markdown: 'Internet_2019',
       'Variable Construct': 'Internet Access'
-    }
-  ],
-  'Physical Environment Variables': [
-    {
-      'Variable Proxy': 'Percent occupied units',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'Housing_2018',
-      'Variable Construct': 'Housing Occupancy Rate'
     },
     {
-      'Variable Proxy': 'Percent vacant units',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'Housing_2018',
-      'Variable Construct': 'Housing Vacancy Rate'
-    },
-    {
-      'Variable Proxy': 'Percentage of population living in current housing for 20+ years',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'Housing_2018',
-      'Variable Construct': 'Long Term Occupancy'
-    },
-    {
-      'Variable Proxy': 'Percent of housing units classified as mobile homes',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'BE01',
-      'Variable Construct': 'Mobile Homes'
-    },
-    {
-      'Variable Proxy': 'Percent of housing units occupied by renters',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'Housing_2018',
-      'Variable Construct': 'Rental Rates'
-    },
-    {
-      'Variable Proxy': 'Housing units per square mile',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE01 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Housing_2018.md">Housing</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE01 / ',
-      markdownText: 'Housing',
-      markdown: 'Housing_2018',
-      'Variable Construct': 'Housing Unit Density'
-    },
-    {
-      'Variable Proxy': 'Classification of areas as rural, urban or suburban using percent rurality (County)',
-      Source: 'USDA-ERS, 2010 & ACS, 2018 5-year',
-      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_County.md">Rural-Urban Classifications (County)</a>',
-      'Spatial Scale': 'County',
-      markdownPrefix: 'BE02 / ',
-      markdownText: 'Rural-Urban Classifications',
-      markdown: 'Rural_Urban_Classification_County',
-      'Variable Construct': 'Urban/Suburban/Rural Classification (County)'
-    },
-    {
-      'Variable Proxy': 'Classification of areas as rural, urban or suburban using RUCA Codes (Tract, Zip)',
-      Source: 'USDA-ERS, 2010',
-      Metadata: 'BE02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Rural_Urban_Classification_T_Z.md">Rural-Urban Classifications (Tract, Zip)</a>',
-      'Spatial Scale': 'Tract, Zip',
-      markdownPrefix: 'BE02 / ',
-      markdownText: 'Rural-Urban Classifications',
-      markdown: 'Rural_Urban_Classification_T_Z',
-      'Variable Construct': 'Urban/Suburban/Rural Classification (Tract, Zip)'
-    },
-    {
-      'Variable Proxy': 'Alcohol outlets per square mile, alcohol outlets per capita',
-      Source: 'InfoGroup, 2018',
-      Metadata: 'BE03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/AlcoholOutlets_2018.md">Alcohol Outlets</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE03 / ',
-      markdownText: 'Alcohol Outlets',
-      markdown: 'AlcoholOutlets_2018',
-      'Variable Construct': 'Alcohol Outlet Density'
-    },
-    {
-      'Variable Proxy': 'US metropolitan areas where black residents experience hypersegregation',
-      Source: 'Massey et al, 2015',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
-      'Spatial Scale': 'County',
-      markdownPrefix: 'BE04 / ',
-      markdownText: 'Community Overlays',
-      markdown: 'Overlay',
-      'Variable Construct': 'Hypersegregated Cities'
-    },
-    {
-      'Variable Proxy': 'US counties where 30% of the population identified as Black or African American',
-      Source: 'US Census, 2010',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
-      'Spatial Scale': 'County',
-      markdownPrefix: 'BE04 / ',
-      markdownText: 'Community Overlays',
-      markdown: 'Overlay',
-      'Variable Construct': 'Southern Black Belt'
-    },
-    {
-      'Variable Proxy': 'Percent area of total land in Native American Reservations',
-      Source: 'US Census, TIGER/Line 2018',
-      Metadata: 'BE04 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Overlay.md">Community Overlays</a>',
-      'Spatial Scale': 'County',
-      markdownPrefix: 'BE04 / ',
-      markdownText: 'Community Overlays',
-      markdown: 'Overlay',
-      'Variable Construct': 'Native American Reservations'
-    },
-    {
-      'Variable Proxy': 'Three index measures of segregation: dissimilarity, interaction, isolation',
-      Source: 'ACS, 2018 5-year',
-      Metadata: 'BE05 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Residential_Seg_Indices.md">Residential Segregation</a>',
-      'Spatial Scale': 'State, County, Zip',
-      markdownPrefix: 'BE05 / ',
-      markdownText: 'Residential Segregation',
-      markdown: 'Residential_Seg_Indices',
-      'Variable Construct': 'Residential Segregation Indices'
-    },
-    {
-      'Variable Proxy': 'Normalized Difference Vegetation Index (NDVI) average value',
-      Source: 'Sentinel-2 MSI, 2018',
-      Metadata: 'BE06 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/NDVI.md">NDVI</a>',
-      'Spatial Scale': 'State, County, Tract, Zip',
-      markdownPrefix: 'BE06 / ',
-      markdownText: 'NDVI',
-      markdown: 'NDVI',
-      'Variable Construct': 'NDVI'
+      'Variable Proxy': 'Number of Primary Care and Specialist Physicians',
+      Source: 'Dartmouth Atlas, 2010; ACS 2018, 5-Year',
+      Metadata: 'Health03 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Health_PCPs.md">Physicians</a>',
+      'Spatial Scale': 'Tract, County, State',
+      markdownPrefix: 'Health03 / ',
+      markdownText: 'Physicians',
+      markdown: 'Health_PCPs',
+      'Variable Construct': 'Physicians'
     }
   ],
   'COVID Variables': [
     {
       'Variable Proxy': 'Percentage of population employed in Essential Jobs as defined during the COVID-19 pandemic',
-      Source: 'ACS, 2018 5-year',
+      Source: 'ACS 2018, 5-Year',
       Metadata: 'EC02 / <a href="https://github.com/GeoDaCenter/opioid-policy-scan/blob/v1.0/data_final/metadata/Job_Categories_byOccupation_2018.md">Jobs by Occupation</a>',
       'Spatial Scale': 'State, County, Tract, Zip',
       markdownPrefix: 'EC02 / ',

--- a/explorer/pages/docs/[md].js
+++ b/explorer/pages/docs/[md].js
@@ -8,7 +8,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm'
 import Footer from "../../components/layout/Footer";
 
-const BASE_DOCS_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/v1.0/data_final/metadata/'
+const BASE_DOCS_URL = 'https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/metadata/'
 const fetchMarkdown = async (url) => await fetch(url).then(r => r.text()).then(r => r.replace('[here](/data_final).', '[here](/download).'))
 
 export default function MarkdownDocs() {

--- a/explorer/pages/docs/index.js
+++ b/explorer/pages/docs/index.js
@@ -22,7 +22,7 @@ const VariableTable = ({table, filters}) =>
       <td width="15%">{row['Variable Construct']}</td>
       <td width="25%">{row['Variable Proxy']}</td>
       <td width="15%">{row['Source']}</td>
-      <td width="15%">{row['markdownPrefix']}<a href={`docs/${row['markdown']}`}>{row['markdownText']}</a></td>
+      <td width="15%"><a href={`docs/${row['markdown']}`}>{row['markdownText']}</a></td>
       <td width="15%">{row['Spatial Scale']}</td>
     </tr> : null)}
     </tbody>

--- a/explorer/pages/docs/index.js
+++ b/explorer/pages/docs/index.js
@@ -31,12 +31,11 @@ const VariableTable = ({table, filters}) =>
 
 const tableNames = [
   "Geographic Boundaries",
-  "Policy Variables",
-  "Health Variables",
-  "Demographic Variables",
+  "Social Variables",
   "Economic Variables",
+  "Policy Variables",
   "Physical Environment Variables",
-  "COVID Variables"
+  "Outcome Variables"
 ]
 
 const uniqueScales = [


### PR DESCRIPTION
Merge in the changes to the data documentation and data download tabs. These include:
- Data documentation page now points to updated metadata, only points to rows with metadata, displays updated source(s) and years, and follows the modern organization/theming from the data dictionary
- Data download page now allows for download of full v1.0 repository or for downloading subsets (or all of) the version 2.0 data

Both sets of changes were accomplished in-part by pointing to the most up-to-date version of the GeoDaCenter/opioid-policy-scan repo, meaning that changes to the organization of that repo might break something. As such, when v2.0 of that repo is released, the links on line 11 of `explorer/pages/docs/[md].js` and line 60 of `explorer/download.js` should be updated to point to the static links.