### PR TITLE
remove references to local paths; switch to shapefiles in S3

### DIFF
--- a/backend/oeps/clients/jcoin.py
+++ b/backend/oeps/clients/jcoin.py
@@ -325,7 +325,6 @@ class DataResource():
         """ Creates a schema from our pre-made external data dictionaries. """
 
         REPO_BASE_URL = "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables"
-        REPO_BASE_URL = "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables"
         GY_LOOKUP = {
             'S': [1980, 1990, 2000, 2010, 'Latest'],
             'C': [1980, 1990, 2000, 2010, 'Latest'],

--- a/backend/oeps/commands.py
+++ b/backend/oeps/commands.py
@@ -51,13 +51,6 @@ def generate_resources_from_oeps_dicts(destination):
         "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/dictionaries/Z_Dict.xlsx",
     ]
 
-    paths = [
-        "~/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/dictionaries/S_Dict.xlsx",
-        "~/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/dictionaries/C_Dict.xlsx",
-        "~/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/dictionaries/T_Dict.xlsx",
-        "~/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/dictionaries/Z_Dict.xlsx",
-    ]
-
     if destination:
         out_dir = destination
         if not os.path.isdir(out_dir):

--- a/backend/oeps/data/resources/spatial_counties2010.json
+++ b/backend/oeps/data/resources/spatial_counties2010.json
@@ -5,11 +5,11 @@
     "title": "County Boundaries, 2010",
     "description": "Shapefile of county boundaries from the US Census Bureau, 2010.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2010.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2010.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2010.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2010.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2010.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2010.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2010.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2010.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2010.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2010.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_counties2018.json
+++ b/backend/oeps/data/resources/spatial_counties2018.json
@@ -5,11 +5,11 @@
     "title": "County Boundaries, 2018",
     "description": "Shapefile of county boundaries from the US Census Bureau, 2018.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2018.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2018.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2018.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2018.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/county/counties2018.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2018.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2018.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2018.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2018.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/counties2018.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_states2010.json
+++ b/backend/oeps/data/resources/spatial_states2010.json
@@ -5,11 +5,11 @@
     "title": "State Boundaries, 2010",
     "description": "Shapefile of state boundaries from the US Census Bureau, 2010.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2010.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2010.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2010.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2010.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2010.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2010.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2010.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2010.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2010.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2010.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_states2018.json
+++ b/backend/oeps/data/resources/spatial_states2018.json
@@ -5,11 +5,11 @@
     "title": "State Boundaries, 2018",
     "description": "Shapefile of state boundaries from the US Census Bureau, 2018.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2018.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2018.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2018.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2018.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/state/states2018.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2018.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2018.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2018.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2018.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/states2018.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_tracts2010.json
+++ b/backend/oeps/data/resources/spatial_tracts2010.json
@@ -5,11 +5,11 @@
     "title": "Census Tract Boundaries, 2010",
     "description": "Shapefile of census tract boundaries from the US Census Bureau, 2010.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2010.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2010.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2010.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2010.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2010.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2010.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2010.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2010.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2010.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2010.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_tracts2018.json
+++ b/backend/oeps/data/resources/spatial_tracts2018.json
@@ -5,11 +5,11 @@
     "title": "Census Tract Boundaries, 2018",
     "description": "Shapefile of census tract boundaries from the US Census Bureau, 2018.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2018.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2018.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2018.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2018.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/tract/tracts2018.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2018.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2018.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2018.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2018.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/tracts2018.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/spatial_zctas2018.json
+++ b/backend/oeps/data/resources/spatial_zctas2018.json
@@ -5,11 +5,11 @@
     "title": "Zip-Code Tabulation Areas, 2018",
     "description": "Shapefile of zip-code tabulation areas (ZCTAs) from the US Census Bureau, 2018.",
     "path": [
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/zcta/zctas2018.shp",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/zcta/zctas2018.shx",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/zcta/zctas2018.dbf",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/zcta/zctas2018.prj",
-        "https://github.com/GeoDaCenter/opioid-policy-scan/raw/main/data_final/geometryFiles/zcta/zctas2018.cpg"
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/zctas2018.shp",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/zctas2018.shx",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/zctas2018.dbf",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/zctas2018.prj",
+        "https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/zctas2018.cpg"
     ],
     "schema": {
         "primaryKey": "HEROP_ID",

--- a/backend/oeps/data/resources/tabular_C_1980.json
+++ b/backend/oeps/data/resources/tabular_C_1980.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "C_1980",
     "name": "c-1980",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/C_1980.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_1980.csv",
     "title": "OEPS Data Aggregated by Census Tract (1980)",
     "description": "This CSV aggregates all 1980 data variables from the OEPS v2 release at the Census Tract level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_C_1990.json
+++ b/backend/oeps/data/resources/tabular_C_1990.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "C_1990",
     "name": "c-1990",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/C_1990.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_1990.csv",
     "title": "OEPS Data Aggregated by Census Tract (1990)",
     "description": "This CSV aggregates all 1990 data variables from the OEPS v2 release at the Census Tract level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_C_2000.json
+++ b/backend/oeps/data/resources/tabular_C_2000.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "C_2000",
     "name": "c-2000",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/C_2000.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_2000.csv",
     "title": "OEPS Data Aggregated by Census Tract (2000)",
     "description": "This CSV aggregates all 2000 data variables from the OEPS v2 release at the Census Tract level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_C_2010.json
+++ b/backend/oeps/data/resources/tabular_C_2010.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "C_2010",
     "name": "c-2010",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/C_2010.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_2010.csv",
     "title": "OEPS Data Aggregated by Census Tract (2010)",
     "description": "This CSV aggregates all 2010 data variables from the OEPS v2 release at the Census Tract level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_C_Latest.json
+++ b/backend/oeps/data/resources/tabular_C_Latest.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "C_Latest",
     "name": "c-latest",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/C_Latest.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_Latest.csv",
     "title": "OEPS Data Aggregated by Census Tract (Latest)",
     "description": "This CSV aggregates all Latest data variables from the OEPS v2 release at the Census Tract level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_S_1980.json
+++ b/backend/oeps/data/resources/tabular_S_1980.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "S_1980",
     "name": "s-1980",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/S_1980.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_1980.csv",
     "title": "OEPS Data Aggregated by State (1980)",
     "description": "This CSV aggregates all 1980 data variables from the OEPS v2 release at the State level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_S_1990.json
+++ b/backend/oeps/data/resources/tabular_S_1990.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "S_1990",
     "name": "s-1990",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/S_1990.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_1990.csv",
     "title": "OEPS Data Aggregated by State (1990)",
     "description": "This CSV aggregates all 1990 data variables from the OEPS v2 release at the State level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_S_2000.json
+++ b/backend/oeps/data/resources/tabular_S_2000.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "S_2000",
     "name": "s-2000",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/S_2000.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_2000.csv",
     "title": "OEPS Data Aggregated by State (2000)",
     "description": "This CSV aggregates all 2000 data variables from the OEPS v2 release at the State level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_S_2010.json
+++ b/backend/oeps/data/resources/tabular_S_2010.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "S_2010",
     "name": "s-2010",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/S_2010.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_2010.csv",
     "title": "OEPS Data Aggregated by State (2010)",
     "description": "This CSV aggregates all 2010 data variables from the OEPS v2 release at the State level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_S_Latest.json
+++ b/backend/oeps/data/resources/tabular_S_Latest.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "S_Latest",
     "name": "s-latest",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/S_Latest.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_Latest.csv",
     "title": "OEPS Data Aggregated by State (Latest)",
     "description": "This CSV aggregates all Latest data variables from the OEPS v2 release at the State level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_T_1980.json
+++ b/backend/oeps/data/resources/tabular_T_1980.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "T_1980",
     "name": "t-1980",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/T_1980.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_1980.csv",
     "title": "OEPS Data Aggregated by County (1980)",
     "description": "This CSV aggregates all 1980 data variables from the OEPS v2 release at the County level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_T_1990.json
+++ b/backend/oeps/data/resources/tabular_T_1990.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "T_1990",
     "name": "t-1990",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/T_1990.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_1990.csv",
     "title": "OEPS Data Aggregated by County (1990)",
     "description": "This CSV aggregates all 1990 data variables from the OEPS v2 release at the County level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_T_2000.json
+++ b/backend/oeps/data/resources/tabular_T_2000.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "T_2000",
     "name": "t-2000",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/T_2000.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_2000.csv",
     "title": "OEPS Data Aggregated by County (2000)",
     "description": "This CSV aggregates all 2000 data variables from the OEPS v2 release at the County level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_T_2010.json
+++ b/backend/oeps/data/resources/tabular_T_2010.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "T_2010",
     "name": "t-2010",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/T_2010.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_2010.csv",
     "title": "OEPS Data Aggregated by County (2010)",
     "description": "This CSV aggregates all 2010 data variables from the OEPS v2 release at the County level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_T_Latest.json
+++ b/backend/oeps/data/resources/tabular_T_Latest.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "T_Latest",
     "name": "t-latest",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/T_Latest.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_Latest.csv",
     "title": "OEPS Data Aggregated by County (Latest)",
     "description": "This CSV aggregates all Latest data variables from the OEPS v2 release at the County level.",
     "scheme": "file",

--- a/backend/oeps/data/resources/tabular_Z_Latest.json
+++ b/backend/oeps/data/resources/tabular_Z_Latest.json
@@ -2,7 +2,7 @@
     "bq_dataset_name": "tabular",
     "bq_table_name": "Z_Latest",
     "name": "z-latest",
-    "path": "/home/adam/Projects/HEROP__OEPS/repo/opioid-policy-scan/data_final/full_tables/Z_Latest.csv",
+    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/Z_Latest.csv",
     "title": "OEPS Data Aggregated by Zip-Code Tabulation Area (ZCTA) (Latest)",
     "description": "This CSV aggregates all Latest data variables from the OEPS v2 release at the Zip-Code Tabulation Area (ZCTA) level.",
     "scheme": "file",


### PR DESCRIPTION
Removes references to local file paths. Also, loads shapefiles from S3 instead of Github, allows larger files to be included in the export package.