### PR TITLE
#117 better handling s3

### DIFF
--- a/backend/oeps/__init__.py
+++ b/backend/oeps/__init__.py
@@ -13,6 +13,7 @@ from oeps.commands.bigquery_upload import bigquery_upload
 from oeps.commands.build_docs import build_docs
 from oeps.commands.build_explorer_docs import build_explorer_docs
 from oeps.commands.build_explorer_map import build_explorer_map
+from oeps.commands.clean_explorer_bucket import clean_explorer_bucket
 from oeps.commands.create_data_package import create_data_package
 from oeps.commands.create_data_dictionaries import create_data_dictionaries
 from oeps.commands.create_table_source import create_table_source
@@ -35,6 +36,7 @@ def create_app():
     app.cli.add_command(build_docs)
     app.cli.add_command(build_explorer_docs)
     app.cli.add_command(build_explorer_map)
+    app.cli.add_command(clean_explorer_bucket)
     app.cli.add_command(create_data_dictionaries)
     app.cli.add_command(create_table_source)
     app.cli.add_command(create_data_package)

--- a/backend/oeps/clients/s3.py
+++ b/backend/oeps/clients/s3.py
@@ -53,13 +53,16 @@ def batch_upload_to_s3(
     for path in paths:
         upload_to_s3(path, prefix, progress_bar)
 
+def clear_s3_bucket(bucket: boto3.s3.Bucket, prefix: str = None):
+    ''' Empty all contents in an s3 bucket beginning with a given prefix '''
+    for i in bucket.objects.filter(Prefix=prefix):
+        print(f'Deleting {i}..')
+        i.delete()
 
-def sync_to_s3(local_dir: Path, prefix: str = None, progress_bar: bool = False):
+def sync_to_s3(local_dir: Path, prefix: str = None, progress_bar: bool = False, clear_bucket: bool = False):
     s3 = boto3.resource("s3")
 
-    for i in s3.Bucket(BUCKET_NAME).objects.filter(Prefix=prefix):
-        print(i)
-        i.delete()
+    if clear_bucket: clear_s3_bucket(s3.Bucket(BUCKET_NAME), prefix)
 
     paths = local_dir.glob("*")
     batch_upload_to_s3(paths, prefix, progress_bar)

--- a/backend/oeps/clients/s3.py
+++ b/backend/oeps/clients/s3.py
@@ -53,16 +53,20 @@ def batch_upload_to_s3(
     for path in paths:
         upload_to_s3(path, prefix, progress_bar)
 
-def clear_s3_bucket(bucket: boto3.s3.Bucket, prefix: str = None):
-    ''' Empty all contents in an s3 bucket beginning with a given prefix '''
-    for i in bucket.objects.filter(Prefix=prefix):
-        print(f'Deleting {i}..')
-        i.delete()
-
-def sync_to_s3(local_dir: Path, prefix: str = None, progress_bar: bool = False, clear_bucket: bool = False):
+def clear_s3_bucket(prefix: str = None, objs_to_keep: list = []):
+    ''' 
+    Empty all contents in an s3 bucket beginning with a given prefix, possibly preserving a few
+    '''
     s3 = boto3.resource("s3")
 
-    if clear_bucket: clear_s3_bucket(s3.Bucket(BUCKET_NAME), prefix)
+    for obj in s3.Bucket(BUCKET_NAME).objects.filter(Prefix=prefix):
+        if obj.key.split('/')[-1] in objs_to_keep: continue
+
+        print(f'Deleting {obj}..')
+        obj.delete()
+
+def sync_to_s3(local_dir: Path, prefix: str = None, progress_bar: bool = False, clear_bucket: bool = False):
+    if clear_bucket: clear_s3_bucket(prefix)
 
     paths = local_dir.glob("*")
     batch_upload_to_s3(paths, prefix, progress_bar)

--- a/backend/oeps/commands/clean_explorer_bucket.py
+++ b/backend/oeps/commands/clean_explorer_bucket.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import click
+
+from oeps.clients.explorer import Explorer
+from oeps.clients.registry import Registry
+
+from ._common_opts import (
+    add_common_opts,
+    registry_opt,
+    explorer_opt,
+)
+
+
+@click.command()
+@add_common_opts(registry_opt, explorer_opt)
+def clean_explorer_bucket(
+    registry_path: Path,
+    explorer_path: Path
+):
+    """Deletes all files from the S3 bucket which are not mentioned in the local
+    explorer/configs/sources.json file. If no sources.json file exists, optionally
+    deletes all uploaded files.
+    """
+
+    registry = Registry(registry_path)
+    ex = Explorer(registry=registry, root_dir=explorer_path)
+    ex.clean_explorer_bucket()


### PR DESCRIPTION
Attempted to resolve #117 by doing the following:

- Edited `s3.sync_to_s3` so that it no longer automatically deletes all files, and instead has a `clear_bucket` parameter to do so. 
- Created a new `s3.clean_s3_bucket` function which clears the bucket. Takes in an optional prefix and `objs_to_keep` command, and can be called from flask with `flask clean-explorer-bucket`. 
  - Intentionally _does_ keep the `counties.csv` and `states.csv` from the explorer branch.

There is maybe an argument that we should add a flag for `clear_bucket` which also calls `clean_s3_bucket`, but I think it's cleaner and more representative of how I anticipate this command will actually get used to abstract it out entirely.
