### PR TITLE
128 move variables

### DIFF
--- a/backend/oeps/__init__.py
+++ b/backend/oeps/__init__.py
@@ -20,6 +20,7 @@ from oeps.commands.create_table_source import create_table_source
 from oeps.commands.merge_data_table import merge_data_table
 from oeps.commands.validate_registry import validate_registry
 from oeps.commands.inspect_csv import inspect_csv
+from oeps.commands.move_variable import move_variable
 from oeps.routes import api
 
 
@@ -43,6 +44,7 @@ def create_app():
     app.cli.add_command(merge_data_table)
     app.cli.add_command(validate_registry)
     app.cli.add_command(inspect_csv)
+    app.cli.add_command(move_variable)
 
     # register routes via blueprints
     app.register_blueprint(api)

--- a/backend/oeps/commands/move_variable.py
+++ b/backend/oeps/commands/move_variable.py
@@ -1,0 +1,93 @@
+import click
+
+from oeps.clients.registry import Registry, TableSource
+
+from ._common_opts import (
+    add_common_opts,
+    registry_opt,
+    overwrite_opt,
+)
+
+
+@click.command()
+@click.option(
+    "--name",
+    "-n",
+    help="Name of variable to move.",
+)
+@click.option(
+    "--source",
+    "-s",
+    help="Name of table source from which the variable will be moved.",
+)
+@click.option(
+    "--target",
+    "-t",
+    help="Name of table source to which this variable will be moved.",
+)
+@add_common_opts(overwrite_opt)
+@add_common_opts(registry_opt)
+def move_variable(name, source, target, overwrite, registry_path):
+    """Move a variable from one table to another. This command is primarily meant to
+    be a corrective tool to help move a set of values for a variable to a different year,
+    after being initially placed in the wrong year.
+    """
+
+    registry = Registry(registry_path)
+
+    variable = registry.variables.get(name)
+    if not variable:
+        print(
+            f"Invalid variable name: {name} -- This variable does not exist in the registry."
+        )
+        exit()
+
+    source = TableSource(source, with_data=True)
+    target = TableSource(target, with_data=True)
+
+    if name not in source.df.columns:
+        print(f"\nThis variable does not exist in the source table: {name}.")
+        exit()
+
+    if name in target.df.columns:
+        print("This variable already has data in the target table source.")
+        if overwrite:
+            c = input("Overwrite that data? Y/n ")
+            if c.lower().startswith("n"):
+                print("cancelling operation")
+                exit()
+        else:
+            print("Use --overwrite to overwrite existing data for this column.")
+            exit()
+
+    source_heropids = set(source.df["HEROP_ID"])
+    target_heropids = set(target.df["HEROP_ID"])
+
+    print(
+        f"number of incoming data poins (i.e. unique HEROP_IDs): {len(source_heropids)}"
+    )
+
+    print("shape of target df")
+    print(target.df.shape)
+
+    in_source_not_in_target = source_heropids - target_heropids
+    print(
+        f"\nHEROP_IDs in source but not in target (data will be lost): {len(in_source_not_in_target)}"
+    )
+    print(in_source_not_in_target)
+
+    in_target_not_in_source = target_heropids - source_heropids
+    print(
+        f"\nHEROP_IDs in target but not in source (data will be empty): {len(in_target_not_in_source)}"
+    )
+    print(in_target_not_in_source)
+
+    c = input("\nContinue?? Y/n ")
+    if c.lower().startswith("n"):
+        exit()
+
+    var_df = source.get_variable_data(name, delete=True)
+    target.merge_df(var_df, overwrite=overwrite)
+
+    registry.sync_variable_table_sources(source)
+    registry.sync_variable_table_sources(target)


### PR DESCRIPTION
Adds a new command to move the content of a single variable from one table source (i.e. CSV) to another. Because all of this data is in version control already, I'm thinking that a "dry run" option is kind of unnecessary, because running the command will update files on disk and these changes can be undone with `git checkout ...`.

Current implementation details:

```
> flask move-variable --help
Usage: flask move-variable [OPTIONS]

  Move a variable from one table to another. This command is primarily meant
  to be a corrective tool to help move a set of values for a variable to a
  different year, after being initially placed in the wrong year.

Options:
  -n, --name TEXT       Name of variable to move.
  -s, --source TEXT     Name of table source from which the variable will be
                        moved.
  -t, --target TEXT     Name of table source to which this variable will be
                        moved.
  --overwrite           Overwrite output content if it already exists.
  --registry-path PATH  Optional override for the registry directory.
  --help                Show this message and exit.
```

Here's an example run with text output:

```
> flask move-variable -n Ruca1 -s tract-2018 -t tract-2010
registry initialized | variables: 356, tables: 50, geodata: 11
Number of incoming data points (i.e. unique HEROP_IDs): 72615
Length of target df: 72611

HEROP_IDs in source but not in target (data will be lost): 4
               HEROP_ID  Ruca1
1213   140US02158000100    NaN
59539  140US46102940900    NaN
59549  140US46102940800    NaN
68479  140US51019050100    NaN

HEROP_IDs in target but not in source (data will be empty): 0
set()

Continue?? Y/n  
```