### PR TITLE
exclude variables from metadata list if they have no table_sources

### DIFF
--- a/backend/oeps/clients/explorer.py
+++ b/backend/oeps/clients/explorer.py
@@ -221,23 +221,24 @@ class Explorer:
                 "variables": [],
             }
             for v in self.registry.variables.values():
-                if v.metadata == m.name:
-                    years = set()
-                    geographies = set()
-                    for ts_id in v.table_sources:
-                        ts = self.registry.table_sources[ts_id]
-                        years.add(ts.data_year)
+                if v.table_sources:
+                    if v.metadata == m.name:
+                        years = set()
+                        geographies = set()
+                        for ts_id in v.table_sources:
+                            ts = self.registry.table_sources[ts_id]
+                            years.add(ts.data_year)
 
-                        gs = self.registry.geodata_sources[ts.geodata_source]
-                        geographies.add(gs.summary_level.title)
+                            gs = self.registry.geodata_sources[ts.geodata_source]
+                            geographies.add(gs.summary_level.title)
 
-                    entry["variables"].append({
-                        "title": v.title,
-                        "name": v.name,
-                        "description": v.description,
-                        "years": sorted(list(years)),
-                        "geographies": sorted(list(geographies)),
-                    })
+                        entry["variables"].append({
+                            "title": v.title,
+                            "name": v.name,
+                            "description": v.description,
+                            "years": sorted(list(years)),
+                            "geographies": sorted(list(geographies)),
+                        })
             entry["variables"].sort(key=lambda x: x['title'])
             metadata_entries[m.name] = entry
 

--- a/explorer/meta/metadataVariables.json
+++ b/explorer/meta/metadataVariables.json
@@ -1852,13 +1852,6 @@
         ]
       },
       {
-        "title": "Count of Federally Qualified Health Centers (FQHCs) within 30-min drive, with Impedance factor",
-        "name": "FqhcCntDr2",
-        "description": "Count of Federally Qualified Health Centers (FQHCs) within a 30-minute driving threshold, with Impedance factor",
-        "years": [],
-        "geographies": []
-      },
-      {
         "title": "Count of Tracts within 30-min drive of Federally Qualified Health Center (FQHC)",
         "name": "FqhcCtTmDr",
         "description": "Number of tracts with Federally Qualified Health Center within a 30-min driving range",
@@ -2713,27 +2706,6 @@
         "geographies": [
           "State"
         ]
-      },
-      {
-        "title": "Average biking time to nearest telehealth buprenorphine provider",
-        "name": "TlBupAvTmBk",
-        "description": "Average biking time (minutes) across tracts in county/state to nearest telehealth buprenorphine provider",
-        "years": [],
-        "geographies": []
-      },
-      {
-        "title": "Average driving time to nearest telehealth buprenorphine provider",
-        "name": "TlBupAvTmDr",
-        "description": "Average driving time (minutes) across tracts in county/state to nearest telehealth buprenorphine provider",
-        "years": [],
-        "geographies": []
-      },
-      {
-        "title": "Average walking time to nearest telehealth buprenorphine provider",
-        "name": "TlBupAvTmWk",
-        "description": "Average walking time (minutes) across tracts in county/state to nearest telehealth buprenorphine provider",
-        "years": [],
-        "geographies": []
       },
       {
         "title": "Biking Time (min) to Nearest Buprenorphine Provider",
@@ -4465,20 +4437,6 @@
     "construct": "Spatial access to HCV Testing",
     "variables": [
       {
-        "title": "Average time drive to nearest HCV testing provider",
-        "name": "HcvAvTmDr",
-        "description": "Mean driving time (minutes) from tracts to nearest HCV testing provider",
-        "years": [],
-        "geographies": []
-      },
-      {
-        "title": "Average time drive to nearest HIV provider",
-        "name": "HivAvTmDr",
-        "description": "Mean driving time (minutes) from tracts to nearest HIV testing provider",
-        "years": [],
-        "geographies": []
-      },
-      {
         "title": "Count of HCV Providers",
         "name": "HcvCntDr",
         "description": "Number of HCV testing providers within a 30-minute drive",
@@ -4501,20 +4459,6 @@
           "Tract",
           "ZCTA"
         ]
-      },
-      {
-        "title": "Count of tracts within 30-min driving range",
-        "name": "HcvCtTmDr",
-        "description": "Number of tracts with an HCV testing provider within a 30-minute driving range",
-        "years": [],
-        "geographies": []
-      },
-      {
-        "title": "Count of tracts within 30-min driving range",
-        "name": "HivCtTmDr",
-        "description": "Number of tracts with an HIV testing provider within a 30-minute driving range",
-        "years": [],
-        "geographies": []
       },
       {
         "title": "Distance to nearest HCV Provider",
@@ -4563,20 +4507,6 @@
           "Tract",
           "ZCTA"
         ]
-      },
-      {
-        "title": "Percent of tracts within 30-min driving range",
-        "name": "HivTmDrP",
-        "description": "Percent of tracts within 30-minute drive to an HIV testing provider",
-        "years": [],
-        "geographies": []
-      },
-      {
-        "title": "Percent of tracts within 30-min driving range",
-        "name": "HcvTmDrP",
-        "description": "Percent of tracts within 30-minute drive to an HCV testing provider",
-        "years": [],
-        "geographies": []
       }
     ]
   },


### PR DESCRIPTION
Fixes this issue:

<img width="2589" height="1119" alt="image" src="https://github.com/user-attachments/assets/b9f16b10-b2c4-4a98-a158-40ad387e18a3" />
