### PR TITLE
Enable S3 upload in CI workflow and add PR testing support

### DIFF
--- a/.github/workflows/generate_derived_data.yml
+++ b/.github/workflows/generate_derived_data.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'backend/oeps/registry/**'
       - 'backend/oeps/data/**'
+  pull_request:
+    paths:
+      - 'backend/oeps/registry/**'
+      - 'backend/oeps/data/**'
   workflow_dispatch:
 
 permissions:
@@ -33,7 +37,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .
-          pip install git+https://github.com/kid-116/md-click@support-arguments
+          pip install click
+          pip install --no-build-isolation git+https://github.com/kid-116/md-click@support-arguments
 
       - name: Create .env file
         working-directory: backend
@@ -64,7 +69,8 @@ jobs:
         working-directory: backend
         run: flask build-docs --bq-only
 
-      - name: Run build-explorer
+      - name: Run build-explorer (with S3 upload on main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: backend
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -72,6 +78,11 @@ jobs:
           AWS_BUCKET_NAME: ${{ steps.aws_config.outputs.bucket_name }}
           AWS_REGION: ${{ steps.aws_config.outputs.region }}
         run: flask build-explorer --upload-map-data
+
+      - name: Run build-explorer (without S3 upload on PRs)
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        working-directory: backend
+        run: flask build-explorer
 
       - name: Check for changes
         id: check_changes
@@ -81,7 +92,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.check_changes.outputs.changes == 'true'
+        if: steps.check_changes.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/generate_derived_data.yml
+++ b/.github/workflows/generate_derived_data.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .
-          pip install mdclick
+          pip install git+https://github.com/kid-116/md-click@support-arguments
 
       - name: Create .env file
         working-directory: backend

--- a/backend/oeps/commands/build_docs.py
+++ b/backend/oeps/commands/build_docs.py
@@ -73,7 +73,7 @@ def build_docs(bq_only:bool, cli_only: bool, registry_only: bool, data_dictionar
         out_file = Path("../docs/src/reference/cli/command-line-reference.md")
 
         temp_docs_dir = TEMP_DIR / "cli-docs"
-        temp_docs_dir.mkdir(exist_ok=True)
+        temp_docs_dir.mkdir(parents=True, exist_ok=True)
         for p in temp_docs_dir.glob("*.md"):
             p.unlink()
 


### PR DESCRIPTION
This PR updates the `generate_derived_data` workflow to enable S3 uploads for production and add PR testing support.

## Changes

- **PR testing**: Added `pull_request` trigger - workflow now runs on PRs for testing (without S3 upload)
- **md-click fix**: Fixed installation to use GitHub repo with `--no-build-isolation` flag
- **Build fix**: Fixed `mkdir` issue in `build_docs.py` to create parent directories

## Testing

Workflow can be tested manually via `workflow_dispatch` or automatically when registry/data files change. On PRs, it will run without uploading to S3, so we can validate the build process before merging.

## Note

You can see the successful test result in here https://github.com/healthyregions/oeps/actions/runs/20867550368/job/59962207317