### PR TITLE
Allow manual workflow dispatch to trigger S3 upload

### DIFF
--- a/.github/workflows/generate_derived_data.yml
+++ b/.github/workflows/generate_derived_data.yml
@@ -61,7 +61,7 @@ jobs:
         run: flask build-docs --bq-only
 
       - name: Run build-explorer (with S3 upload on main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         working-directory: backend
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This PR fixes the workflow so that manual dispatch (`workflow_dispatch`) can trigger S3 uploads when running on `main` branch.

## Changes

- Updated the condition on line 64 to allow both `push` and `workflow_dispatch` events to trigger S3 upload
- This enables testing the workflow with S3 upload via manual trigger

## Before
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
