### PR TITLE
Fix workflow_dispatch: prevent both S3 and non-S3 steps from running, enable commits

### DIFF
--- a/.github/workflows/generate_derived_data.yml
+++ b/.github/workflows/generate_derived_data.yml
@@ -71,7 +71,7 @@ jobs:
         run: flask build-explorer --upload-map-data
 
       - name: Run build-explorer (without S3 upload on PRs)
-        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        if: github.event_name == 'pull_request'
         working-directory: backend
         run: flask build-explorer
 
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.check_changes.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.check_changes.outputs.changes == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
This PR fixes two issues with manual workflow dispatch (`workflow_dispatch`) that were preventing it from working correctly.

## Problems Fixed

1. **Both steps run on workflow_dispatch**: When manually triggering on `main`, both the S3 upload step and non-S3 step ran, causing `sources.json` to be overwritten with local file references instead of S3 URLs.

2. **Commit step doesn't run**: The commit step only allowed `push` events, so manual triggers didn't commit generated files.

## Changes

- **Non-S3 step** (line 74): Now only runs on `pull_request` events (not on `workflow_dispatch`)
- **Commit step** (line 86): Now also allows `workflow_dispatch` events on `main` branch

## Scenarios

**1. PR merged to main (push event):**
- S3 upload runs
- Non-S3 step doesn't run
- Commit runs
- Result: S3 upload only, then commits

**2. Manual trigger on main (workflow_dispatch):**
- S3 upload runs
- Non-S3 step doesn't run
- Commit runs
- Result: S3 upload only, then commits

**3. Pull Request:**
- S3 upload doesn't run
- Non-S3 step runs
- Commit doesn't run
- Result: Non-S3 build only (for testing)

This ensures only one build-explorer step runs per scenario, preventing `sources.json` from being overwritten, and allows manual triggers to properly commit generated files.