### PR TITLE
Fix workflow commit step to bypass branch protection using PAT

### DIFF
--- a/.github/workflows/generate_derived_data.yml
+++ b/.github/workflows/generate_derived_data.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -87,7 +87,8 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git remote set-url origin https://${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git add -A
           git commit -m "chore: auto-generate derived docs and explorer data"
-          git push
+          git push origin HEAD:main
 


### PR DESCRIPTION
Fixes the workflow commit step failing due to branch protection on `main`.

## Changes

- Updated checkout step to use `WORKFLOW_PAT` secret (falls back to `GITHUB_TOKEN`)
- Updated commit step to use PAT in git remote URL for authentication
- PAT created by ywkim's account and added as `WORKFLOW_PAT` secret
- ywkim's account added to branch protection bypass list

The workflow can now push commits to `main` using the PAT, bypassing the branch protection requirement.