### PR TITLE
PagesCMS workarounds: optional table_sources, metadata .json stripping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 
 .DS_Store
+
+credentials/

--- a/backend/oeps/models.py
+++ b/backend/oeps/models.py
@@ -119,12 +119,15 @@ class VariableModel(BaseModel):
     description: str
     longitudinal: bool = False
     analysis: bool = False
-    table_sources: list[str]
+    table_sources: list[str] = []
     metadata: str
 
     @classmethod
     def from_json_file(cls, path: Path) -> "VariableModel":
         data = load_entry(path)
+        # PagesCMS stores metadata as "Access_MOUDs.json"; registry expects base name
+        if data.get("metadata", "").endswith(".json"):
+            data["metadata"] = data["metadata"][: -len(".json")]
         return cls(**data)
 
     def to_json_file(self, registry_path: Path):

--- a/backend/oeps/models.py
+++ b/backend/oeps/models.py
@@ -125,7 +125,7 @@ class VariableModel(BaseModel):
     @classmethod
     def from_json_file(cls, path: Path) -> "VariableModel":
         data = load_entry(path)
-        # PagesCMS stores metadata as "Access_MOUDs.json"; registry expects base name
+        # PagesCMS stores metadata with .json suffix; registry expects base name only
         if data.get("metadata", "").endswith(".json"):
             data["metadata"] = data["metadata"][: -len(".json")]
         return cls(**data)

--- a/docs/src/guides/merging-data-into-oeps.md
+++ b/docs/src/guides/merging-data-into-oeps.md
@@ -56,7 +56,7 @@ flask inspect-csv -s path/to/MyNewCountyData2021.csv
 Variables created via [PagesCMS](https://app.pagescms.org/healthyregions/oeps) may have gaps that would historically block the merge. The OEPS backend includes workarounds:
 
 - **table_sources**: CMS does not add `table_sources` when creating new variables. The backend treats it as optional (default `[]`), so the registry loads successfully. When you run the merge, `flask merge-csv` populates `table_sources` for any variable whose column is merged into the target table.
-- **metadata .json suffix**: The CMS metadata dropdown stores `Access_MOUDs.json` instead of `Access_MOUDs`. The backend strips the `.json` suffix when loading variable JSON files, so both forms work.
+- **metadata .json suffix**: The CMS metadata dropdown stores the full filename (e.g. with `.json` suffix) instead of the base name. The backend strips the `.json` suffix when loading variable JSON files, so both forms work.
 
 You can run the merge without manually editing variable files for these issues.
 

--- a/docs/src/guides/merging-data-into-oeps.md
+++ b/docs/src/guides/merging-data-into-oeps.md
@@ -51,6 +51,15 @@ flask inspect-csv -s path/to/MyNewCountyData2021.csv
 - If yes, great! You are ready to [merge data into OEPS](#merge-data-into-oeps).
 - If no, you need to [create a new variable entry](creating-metadata-and-variables.md#creating-a-new-variable-entry) for every new incoming variable.
 
+## PagesCMS workarounds
+
+Variables created via [PagesCMS](https://app.pagescms.org/healthyregions/oeps) may have gaps that would historically block the merge. The OEPS backend includes workarounds:
+
+- **table_sources**: CMS does not add `table_sources` when creating new variables. The backend treats it as optional (default `[]`), so the registry loads successfully. When you run the merge, `flask merge-csv` populates `table_sources` for any variable whose column is merged into the target table.
+- **metadata .json suffix**: The CMS metadata dropdown stores `Access_MOUDs.json` instead of `Access_MOUDs`. The backend strips the `.json` suffix when loading variable JSON files, so both forms work.
+
+You can run the merge without manually editing variable files for these issues.
+
 ## Workflow
 
 Listed here in logical order, though often only the later steps will be needed.


### PR DESCRIPTION
## Summary
Adds backend changes so the merge command works when variables are created via PagesCMS.

## Changes
- backend/oeps/models.py
  - Make table_sources optional with default [] so variables without table_sources still load.
  - In Variable.from_json_file(), strip .json from the metadata field when present so both Access_MOUDs and Access_MOUDs.json work.
- docs/src/guides/merging-data-into-oeps.md
  - Add a "PagesCMS workarounds" section describing these behaviors.

## Context
PagesCMS-created variables can omit table_sources and use "metadata": "Access_MOUDs.json". The registry expected table_sources and metadata without the .json suffix, so the merge command failed on load. Adam recommended these workarounds. Empty table_sources is acceptable; the merge command fills it when it runs.

Closes #300 