### PR TITLE
Implement data packages GitHub workflow and stable download links

### DIFF
--- a/.github/workflows/create_data_packages.yml
+++ b/.github/workflows/create_data_packages.yml
@@ -1,0 +1,54 @@
+# Creates Frictionless data packages and uploads to S3 when package rules change.
+# See: https://github.com/healthyregions/oeps/issues/277
+name: Create Data Packages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/oeps/data/package_rules/**'
+  workflow_dispatch:
+
+jobs:
+  create_data_packages:
+    runs-on: ubuntu-latest
+    # Only upload on main; allow manual trigger
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+
+      - name: Create .env file
+        working-directory: backend
+        run: echo "FLASK_APP=oeps" > .env
+
+      - name: Create and upload data packages
+        working-directory: backend
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          for dir in oeps/data/package_rules/*/; do
+            name=$(basename "$dir")
+            echo "Creating data package: $name"
+            extra=""
+            if [ "$name" = "DSuite2023" ]; then
+              extra="--skip-foreign-keys"
+            fi
+            flask create-data-package -c "$name" --zip --upload --skip-validation --stable-name $extra --overwrite
+          done

--- a/backend/oeps/commands/create_data_package.py
+++ b/backend/oeps/commands/create_data_package.py
@@ -77,6 +77,13 @@ from ._common_opts import (
     default=False,
     help="Don't run data package validation on the final output.",
 )
+@click.option(
+    "--stable-name",
+    is_flag=True,
+    default=False,
+    help="Use a stable output name without date (e.g. oeps-DSuite2018.zip). "
+    "Use with --upload so download page links never need updating.",
+)
 @add_common_opts(overwrite_opt, registry_opt, data_dir_opt, verbose_opt)
 def create_data_package(
     destination,
@@ -87,6 +94,7 @@ def create_data_package(
     no_cache,
     skip_foreign_keys,
     skip_validation,
+    stable_name,
     check_rules,
     overwrite,
     registry_path,
@@ -123,7 +131,10 @@ def create_data_package(
             print(f"Expected path: {rules_dir.resolve()}")
             exit()
 
-        out_name = f"oeps-{config_name}_{datetime.now().date().isoformat()}"
+        if stable_name:
+            out_name = f"oeps-{config_name}"
+        else:
+            out_name = f"oeps-{config_name}_{datetime.now().date().isoformat()}"
         out_name = out_name + "_no_foreign_keys" if skip_foreign_keys else out_name
         out_path = Path(destination, out_name)
 

--- a/explorer/pages/download.js
+++ b/explorer/pages/download.js
@@ -208,7 +208,7 @@ export default function Download() {
                 <Link href="https://github.com/healthyregions/oeps/raw/refs/heads/main/docs/src/reference/data-dictionaries/DSuite2018-data-dictionary.xlsx">Download DSuite2018 data dictionary</Link>
               </li>
               <li>
-                <Link href="https://herop-oeps.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2018_2026-01-15.zip">Download DSuite2018 data package [158mb]</Link>
+                <Link href="https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2018.zip">Download DSuite2018 data package (100mb+)</Link>
               </li>
             </ul>
             <h4 id="dsuite-2023">DSuite2023</h4>
@@ -218,7 +218,7 @@ export default function Download() {
                 <Link href="https://github.com/healthyregions/oeps/raw/refs/heads/main/docs/src/reference/data-dictionaries/DSuite2023-data-dictionary.xlsx">Download DSuite2023 data dictionary</Link>
               </li>
               <li>
-                <Link href="https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2023_2026-01-26_no_foreign_keys.zip">Download DSuite2023 data package [166mb]</Link>
+                <Link href="https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2023_no_foreign_keys.zip">Download DSuite2023 data package (100mb+)</Link>
               </li>
             </ul>
             <h3 id="csv-downloads">All data by year</h3>


### PR DESCRIPTION
## Description
Implements issue #277 by automating data package creation and updating the download page so links stay stable.

Closes: #277 

## Changes
- GitHub workflow (.github/workflows/create_data_packages.yml): Runs when backend/oeps/data/package_rules/** changes. For each config (DSuite2018, DSuite2023), runs flask create-data-package with --zip, --upload, --skip-validation, and --stable-name. Uses --skip-foreign-keys for DSuite2023.
- --stable-name option (create_data_package.py): Outputs fixed filenames (e.g. oeps-DSuite2018.zip) instead of date-stamped names, so S3 uploads overwrite the same object and links do not need updates.
- Download page (explorer/pages/download.js): Switches to stable S3 URLs on herop-geodata, and changes the size labels from fixed values to "(100mb+)".

## Test 
1. Set up the backend
```
cd c:\workspace-healthyregions\oeps\backend
pip install -e .
echo FLASK_APP=oeps > .env
cd c:\workspace-healthyregions\oeps\backendpip install -e .echo FLASK_APP=oeps > .env
```
2. Run the command (dry run, no upload)
```
flask create-data-package -c DSuite2018 --zip --skip-validation --stable-name --overwrite
```
This should:
- Build the package and output to something like backend/oeps/data-packages/oeps-DSuite2018/
- Produce oeps-DSuite2018.zip (stable name, no date)
- Run without --upload so nothing goes to S3

3. Run for DSuite2023
```
flask create-data-package -c DSuite2023 --zip --skip-validation --stable-name --skip-foreign-keys --overwrite
```
Output should be oeps-DSuite2023_no_foreign_keys.zip.

4. Test with upload (optional)
If you have AWS credentials:
```
$env:AWS_ACCESS_KEY_ID="your-key"
$env:AWS_SECRET_ACCESS_KEY="your-secret"
$env:AWS_BUCKET_NAME="herop-geodata"
$env:AWS_REGION="us-east-2"
flask create-data-package -c DSuite2018 --zip --upload --skip-validation --stable-name --overwrite
$env:AWS_ACCESS_KEY_ID="your-key"$env:AWS_SECRET_ACCESS_KEY="your-secret"$env:AWS_BUCKET_NAME="herop-geodata"$env:AWS_REGION="us-east-2"flask create-data-package -c DSuite2018 --zip --upload --skip-validation --stable-name --overwrite
```
Warning: this uploads to the real S3 bucket.

5. Test the download page
```
cd c:\workspace-healthyregions\oeps\explorer
npm run dev
cd c:\workspace-healthyregions\oeps\explorernpm run dev
```
Then open http://localhost:3000/download#data-packages and confirm:
- Links point to oeps-DSuite2018.zip and oeps-DSuite2023_no_foreign_keys.zip
- Labels say "(100mb+)"

## Notes
- Requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET_NAME, and AWS_REGION as GitHub Actions secrets.
- Both packages now use the herop-geodata bucket.