### PR TITLE
Docs: Add image guidelines to metadata/README.md

### DIFF
--- a/metadata/README.md
+++ b/metadata/README.md
@@ -14,3 +14,46 @@
 - Be sure to check URLs to ensure they are working. If not, update. 
 - In addition to updating the table, also carefully read and update (if necessary) every other section. If the URL where you sourced the data changed this time, add that to the metadata source description. Indicated when you pulled data, when appropriate.
 - Add more tips here for your fellow writers in the future.
+
+## Adding images
+
+The OEPS docs page renders metadata markdown with ReactMarkdown, which does **not** render raw HTML. Use **Markdown image syntax** so images show correctly on the OEPS docs page.
+
+### HTML vs Markdown (use Markdown)
+
+When you drop or paste an image into GitHub’s markdown editor, it may insert an HTML `<img>` tag. That works when viewing the file on GitHub, but **the OEPS docs page will not render it**—the image will not show. Use Markdown syntax instead.
+
+| Don’t use (HTML – won’t show on OEPS docs) | Do use (Markdown – works on OEPS docs) |
+|-------------------------------------------|----------------------------------------|
+| `<img width="1492" height="657" alt="Screenshot" src="https://github.com/user-attachments/assets/abc123" />` | `![Screenshot](https://github.com/user-attachments/assets/abc123)` |
+
+Same image URL; only the syntax changes. Replace any auto-generated `<img>` with the `![alt](url)` form.
+
+### Option 1: GitHub paste/drop (recommended)
+
+1. Paste or drop the image into a **PR or issue comment** so GitHub hosts it.
+2. Right‑click the pasted image → **Copy image address**.
+3. In your metadata `.md` file, add:
+
+   ```markdown
+   ![Short description of the image](paste-the-copied-url-here)
+   ```
+
+4. Do not use the auto-generated HTML when you drop an image into the .md file; use this Markdown line so the image renders on the OEPS docs page.
+
+**Example:**
+
+```markdown
+![Travel time to nearest provider](https://github.com/user-attachments/assets/98ccd48e-e3a8-40a7-bd64-f6e9251cca45)
+```
+
+### Option 2: Use `metadata/images/`
+
+1. Add your image file to the `metadata/images/` folder in the repo (create the folder if needed).
+2. In your metadata `.md` file, reference it with the raw GitHub URL:
+
+   ```markdown
+   ![Short description of the image](https://raw.githubusercontent.com/healthyregions/oeps/main/metadata/images/your-filename.png)
+   ```
+
+3. The URL above points at `main`. If you add an image on a feature branch, use a branch-specific URL during development (replace `main` with your branch name), then switch to `main` after the PR is merged.


### PR DESCRIPTION
## Summary

Adds an **Adding images** section to `metadata/README.md` so contributors know how to add images that render correctly on the OEPS docs page.

## Changes

- **HTML vs Markdown:** Short explanation that the OEPS docs use ReactMarkdown and don’t render raw HTML. Comparison table: don’t use `<img>` (won’t show), do use `![alt](url)`.
- **Option 1 (recommended):** GitHub paste/drop — paste image in a PR/issue, copy image address, then add `![description](url)` in the metadata `.md`. Includes an example.
- **Option 2:** Use `metadata/images/` — add the file to the repo and reference it with the raw GitHub URL; note about branch-specific URLs.

## Context

The OEPS docs page renders metadata with ReactMarkdown, which does not render `<img>` tags. Dropping images in GitHub’s editor inserts HTML, so images didn’t show on the docs until we switched to Markdown syntax. This doc captures the recommended workflow and the HTML vs Markdown difference for the team.