### PR TITLE
Fix BigQuery upload: round NUMERIC values to 9 decimal places

### DIFF
--- a/backend/oeps/clients/bigquery.py
+++ b/backend/oeps/clients/bigquery.py
@@ -239,7 +239,7 @@ class BigQuery:
                             # special handle string values like '23493.3434'
                             row[k] = int(round(float(row[k])))
                     if field_types[k] == "number":
-                        row[k] = float(row[k])
+                        row[k] = round(float(row[k]), 9)  # BigQuery NUMERIC allows max 9 decimal places
                     if field_types[k] == "boolean":
                         if row[k] in [
                             1,


### PR DESCRIPTION
Closes: #322 

## Summary

Fixes `flask bigquery-upload` failing when loading tables that contain decimal values with more than 9 decimal places (e.g. `county-1990` and others). BigQuery NUMERIC allows at most 9 decimal places; source data can have more (e.g. `22776.5332919661` for `BlackE`), which caused:

`Invalid NUMERIC value: 22776.5332919661 Field: BlackE`

## Change

In `backend/oeps/clients/bigquery.py`, when preparing rows for load, numeric values (registry type `"number"` → BigQuery NUMERIC) are now rounded to 9 decimal places before serialization:

row[k] = round(float(row[k]), 9)  # BigQuery NUMERIC allows max 9 decimal places
