### PR TITLE
Fix Frictionless data package validation (FK to geography-keys CSV; enable CI validation)

### DIFF
--- a/.github/workflows/create_data_packages.yml
+++ b/.github/workflows/create_data_packages.yml
@@ -46,9 +46,5 @@ jobs:
           for dir in oeps/data/package_rules/*/; do
             name=$(basename "$dir")
             echo "Creating data package: $name"
-            extra=""
-            if [ "$name" = "DSuite2023" ]; then
-              extra="--skip-foreign-keys"
-            fi
-            flask create-data-package -c "$name" --zip --upload --skip-validation --stable-name $extra --overwrite
+            flask create-data-package -c "$name" --zip --upload --stable-name --overwrite
           done

--- a/backend/oeps/clients/frictionless.py
+++ b/backend/oeps/clients/frictionless.py
@@ -115,6 +115,54 @@ class DataPackage:
             gs = self.registry.geodata_sources.get(list(gs_lookup.keys())[0])
             geodata_sources.append(gs)
 
+            df = gs.get_blank_dataframe()
+
+            # Tabular geography key table for Frictionless FK checks. Validating FKs against the
+            # shapefile resource fails (FileResource has no row_stream); see issue #311.
+            if not skip_foreign_keys:
+                keys_resource_name = f"{rules_file.stem}-geography-keys"
+                keys_filename = f"{rules_file.stem}-geography-keys.csv"
+                keys_path_rel = f"data/{keys_filename}"
+                geo_key_col = "ZCTA5" if rules_file.stem == "zcta" else "FIPS"
+                keys_schema_obj = {
+                    "primaryKey": "HEROP_ID",
+                    "fields": [
+                        {
+                            "title": "HEROP_ID",
+                            "name": "HEROP_ID",
+                            "type": "string",
+                            "example": "050US01001",
+                            "description": "A derived unique id corresponding to the relevant geographic unit.",
+                            "metadata": "Geographic_Boundaries",
+                        },
+                        {
+                            "title": "ZCTA5" if geo_key_col == "ZCTA5" else "FIPS",
+                            "name": geo_key_col,
+                            "type": "string",
+                            "example": "22001",
+                            "description": (
+                                "Zip Code for this geographic unit."
+                                if geo_key_col == "ZCTA5"
+                                else "FIPS code for this geographic unit."
+                            ),
+                            "metadata": "Geographic_Boundaries",
+                        },
+                    ],
+                }
+                keys_resource = {
+                    "name": keys_resource_name,
+                    "title": f"Geography keys ({rules_file.stem})",
+                    "format": "csv",
+                    "mediatype": "text/csv",
+                    "path": keys_path_rel,
+                    "schema": f"schemas/{keys_resource_name}.json",
+                }
+                keys_outpath = Path(d_path, keys_filename)
+                df[["HEROP_ID", geo_key_col]].to_csv(keys_outpath, index=False)
+                write_json(keys_schema_obj, Path(self.path, keys_resource["schema"]))
+                self.schema["resources"].append(keys_resource)
+                self.clean_data_resource(keys_resource)
+
             ts_resource = {
                 "name": rules_file.stem,
                 "title": rules_file.stem,
@@ -139,7 +187,7 @@ class DataPackage:
                 resource_schema["foreignKeys"] = [{
                     "fields": "HEROP_ID",
                     "reference": {
-                        "resource": gs.name,
+                        "resource": f"{rules_file.stem}-geography-keys",
                         "fields": "HEROP_ID"
                     }
                 }]
@@ -162,7 +210,6 @@ class DataPackage:
                     "metadata": "Geographic_Boundaries"
                 })
 
-            df = gs.get_blank_dataframe()
             for row in self.rules_rows:
                 ## skip HEROP_ID and FIPS, as they are already in the blank df
                 if row["name"] in ["HEROP_ID", "FIPS"]:

--- a/backend/oeps/commands/create_data_package.py
+++ b/backend/oeps/commands/create_data_package.py
@@ -68,8 +68,8 @@ from ._common_opts import (
     "--skip-foreign-keys",
     is_flag=True,
     default=False,
-    help="Don't define foreign keys in the output data package. This is needed to avoid validation errors that "
-    "occur when Shapefiles are used in foreign keys.",
+    help="Don't define foreign keys in the output data package and omit geography-keys CSV resources. "
+    "By default, FKs reference a tabular geography-keys file (not the shapefile) so validation can run.",
 )
 @click.option(
     "--skip-validation",
@@ -106,8 +106,7 @@ def create_data_package(
 
     The resulting package will be validated against the `frictionless` standard using that Python library.
 
-    `--skip-foreign-keys` to skip the creation of foreign keys--useful because foreign keys to shapefiles break
-    validation.
+    `--skip-foreign-keys` to omit foreign keys and geography-keys tables (packages without relational metadata).
 
     `--skip-validation` to skip the final step of running validation on the output package.
     """


### PR DESCRIPTION
Closes #311 

## Summary
- Resolves foreign key validation failures when CSV resources referenced shapefiles (`FileResource` has no `row_stream` in frictionless-py) — see #311.
- Adds a tabular `*-geography-keys.csv` resource per geography (from the same `get_blank_dataframe()` as the main tables) and points `foreignKeys` at that CSV instead of the shapefile.
- Removes `--skip-validation` from the Create Data Packages workflow and drops the `DSuite2023`-only `--skip-foreign-keys` workaround.
## How to test
1. **Local package build + validation** (from repo `backend/` with `FLASK_APP=oeps`):
   ```bash
   pip install -e .
   flask create-data-package -c DSuite2018 --overwrite
   flask create-data-package -c DSuite2023 --overwrite
Omit --skip-validation or --skip-foreign-keys. Confirm the command finishes with exit code 0 and the log ends with a validation summary showing 0 errors (tasks include *-geography-keys resources and geo shapefile resources).

## Optional — inspect output

Open the generated folder under backend/.temp/data-packages/ (or your --destination) and check data-package.json: main CSV foreignKeys should reference {county|state|tract|zcta}-geography-keys, not geo-* shapefile names.
Confirm data/*-geography-keys.csv files exist next to the main geography CSVs.
CI

After merge, or on this branch: run the Create Data Packages workflow manually (workflow_dispatch) if package_rules did not change (no automatic run). Confirm the job succeeds.

## Note on follow-up fixes
Validation is now enforced in CI instead of skipped. The first few runs after this change may surface new failures (e.g. schema/FK mismatches, data edge cases, or frictionless upgrades) that were previously hidden. If a workflow run fails, use the job logs and the generated error-report.json in the package output (when produced) to diagnose, then open a small follow-up PR to adjust package structure or data as needed. That tightening is expected and improves long-term package quality.