### PR TITLE
Created a Github action for validating the registry

### DIFF
--- a/.github/workflows/validate_registry.yml
+++ b/.github/workflows/validate_registry.yml
@@ -1,0 +1,39 @@
+# Runs registry consistency checks on pull requests that touch registry or table data.
+# See: https://github.com/healthyregions/oeps/issues/262
+name: Validate registry
+
+on:
+  pull_request:
+    paths:
+      - 'backend/oeps/registry/**'
+      - 'backend/oeps/data/**'
+      - '.github/workflows/validate_registry.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate_registry:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+
+      - name: Validate registry
+        working-directory: backend
+        env:
+          FLASK_APP: oeps
+        run: flask validate-registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- GitHub Action **Validate registry** that runs `flask validate-registry` on pull requests when `backend/oeps/registry/**`, `backend/oeps/data/**`, or the workflow file changes, plus manual **`workflow_dispatch`** ([#262](https://github.com/healthyregions/oeps/issues/262)).
+
 - GitHub Action to create and upload Frictionless data packages when `backend/oeps/data/package_rules/**` changes ([#277](https://github.com/healthyregions/oeps/issues/277)).
 
 - `--stable-name` option for `flask create-data-package` so package filenames are fixed (e.g. `oeps-DSuite2018.zip`) and download links do not need updates ([#277](https://github.com/healthyregions/oeps/issues/277)).


### PR DESCRIPTION
Short reference for [issue #262](https://github.com/healthyregions/oeps/issues/262): run `flask validate-registry` on relevant PRs.

## Summary

- Adds a **GitHub Actions** check so the backend **registry and table CSV layout** are exercised automatically when someone opens or updates a PR that touches registry or table data.
- Runs the same **`flask validate-registry`** command you can run locally, so broken references (for example missing table CSV files, bad `table_sources` / `geodata_source` names, or metadata keys that do not exist) surface as a **failed check** on the PR when the command errors.
- Adds a **short doc** (this page) and **MkDocs** nav so contributors know when the workflow runs and how to test it.

## What changed

- Added `.github/workflows/validate_registry.yml`: on **`pull_request`** that touches `backend/oeps/registry/**`, `backend/oeps/data/**`, or that workflow file, CI runs **`pip install -e .`** in `backend/` then **`FLASK_APP=oeps flask validate-registry`** (Python 3.11, `contents: read` only).
- **`workflow_dispatch`**: run manually from **Actions → Validate registry → Run workflow**.
- Docs: this file and `docs/mkdocs.yml` nav (under **OEPS Backend**).

## How to test

1. **Local:** `cd backend`, set `FLASK_APP=oeps`, run `flask validate-registry` (expect `all checks complete.` and exit **0**).
2. **On GitHub:** open or update a PR that changes registry/data paths above → **Checks** → **Validate registry** should pass.
3. **Manual:** **Actions → Validate registry → Run workflow** on your branch.

**Note:** Some validation messages are print-only today; CI fails on command errors (e.g. bad JSON), not on every printed warning. Hardening exit codes can be a follow-up.