### PR TITLE
Fix map legend and tooltip showing `0` for very small numeric values (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,4 +36,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Explorer map: legend bin labels and polygon hover tooltips use magnitude-aware numeric formatting so very small non-zero values are not shown as `0` ([#366](https://github.com/healthyregions/oeps/issues/366)).
+
 - Frictionless data package validation no longer fails when CSV foreign keys pointed at shapefile resources (`FileResource` / `row_stream`) ([#311](https://github.com/healthyregions/oeps/issues/311)).

--- a/explorer/_webgeoda/utils/formatMapNumeric.js
+++ b/explorer/_webgeoda/utils/formatMapNumeric.js
@@ -1,0 +1,47 @@
+/**
+ * Format numeric values for map legend labels and hover tooltips.
+ * Very small magnitudes (e.g. some 2SFCA fields) must not round to "0".
+ */
+export function formatMapNumeric(value) {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  if (Object.is(n, -0) || n === 0) return "0";
+  const abs = Math.abs(n);
+  if (abs >= 1) {
+    return n.toLocaleString("en-US", { maximumFractionDigits: 2 });
+  }
+  if (abs >= 0.01) {
+    return n.toLocaleString("en-US", {
+      maximumFractionDigits: 4,
+      minimumFractionDigits: 0,
+    });
+  }
+  if (abs >= 1e-7) {
+    return n.toLocaleString("en-US", {
+      maximumFractionDigits: 9,
+      minimumFractionDigits: 0,
+    });
+  }
+  return n.toExponential(2);
+}
+
+/** Legend bins may be numeric breaks or categorical / natural-break labels (strings). */
+export function formatLegendLabel(bin) {
+  if (bin == null || bin === "") return "";
+  if (typeof bin === "number" && Number.isFinite(bin)) {
+    return formatMapNumeric(bin);
+  }
+  if (typeof bin === "string") {
+    const t = bin.trim();
+    const n = Number(t);
+    if (
+      t !== "" &&
+      Number.isFinite(n) &&
+      /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(t)
+    ) {
+      return formatMapNumeric(n);
+    }
+    return bin;
+  }
+  return String(bin);
+}

--- a/explorer/components/map/Legend.js
+++ b/explorer/components/map/Legend.js
@@ -1,4 +1,5 @@
 import styles from "./MainMap.module.css";
+import { formatLegendLabel } from "../../_webgeoda/utils/formatMapNumeric";
 
 export default function Legend(props) {
   return (
@@ -17,7 +18,7 @@ export default function Legend(props) {
         </div>
         <div className={`${styles.legendLabels} ${props.ordinal && styles.categoricalLegendLabels}`}>
           {props.bins?.map((bin, i) => (
-            <span key={`legend-label-${i}`}>{bin?.toLocaleString("en")}</span>
+            <span key={`legend-label-${i}`}>{formatLegendLabel(bin)}</span>
           ))}
         </div>
       </div>

--- a/explorer/components/map/MapTooltip.js
+++ b/explorer/components/map/MapTooltip.js
@@ -2,6 +2,13 @@ import { useState, useEffect } from 'react';
 import styles from "./MainMap.module.css";
 import { useSelector } from "react-redux";
 import { handleLoadData } from '../../_webgeoda/utils/data'
+import { formatMapNumeric } from '../../_webgeoda/utils/formatMapNumeric'
+
+const formatTooltipValue = (value) => {
+  if (value === null || value === undefined || value === '') return value
+  const n = Number(value)
+  return Number.isFinite(n) ? formatMapNumeric(n) : String(value)
+}
 
 const pad = (val, len, padChar) => `${val}`.length >= len ? ''+val : pad(`${padChar}${val}`, len, padChar)
 
@@ -80,11 +87,7 @@ export default function MapTooltip() {
       {currentHoverTarget.data.map((entry, idx) => (
         <p key={`tooltip-${entry.value}-${idx}`}>
 
-          <b>{entry.name}</b>: {
-            +entry.value
-              ? Math.round(entry.value * 100) / 100
-              : entry.value
-            }
+          <b>{entry.name}</b>: {formatTooltipValue(entry.value)}
         </p>
       ))}
     </div>


### PR DESCRIPTION
## Description

On `/map`, the choropleth could color features correctly while the **legend bin labels** and **polygon hover tooltip** showed **`0`** for small non-zero values (e.g. tract-level 2SFCA-style metrics).

- **Tooltip:** Values were rounded with `Math.round(value * 100) / 100`, which collapses tiny magnitudes to `0`.
- **Legend:** Bin edges used `toLocaleString("en")` without options suited to very small numbers.

This PR adds **`formatMapNumeric`** / **`formatLegendLabel`** in `explorer/_webgeoda/utils/formatMapNumeric.js` and wires them into **`MapTooltip.js`** and **`Legend.js`**, using magnitude-aware formatting (more fraction digits or scientific notation when needed) while leaving non-numeric / categorical legend labels unchanged.

Closes #366 (or link issue as appropriate for your repo workflow).

## How to test

1. From repo root: `cd explorer`
2. Install deps (if needed): `npm install --legacy-peer-deps` (or your usual command)
3. Ensure **`NEXT_PUBLIC_MAPBOX_TOKEN`** is set in `explorer/.env` or `explorer/.env.local`, then restart the dev server after any env change.
4. Run: `npm run dev`
5. Open **`http://localhost:3000/map`**
6. Choose a geography and variable known to have **very small non-zero** values (e.g. tract-level access / FCA-style metrics if available).
7. Confirm:
   - **Hover tooltip** shows a meaningful non-zero display (not `0`) when the feature is colored as non-empty.
   - **Legend** bin labels show appropriate precision or scientific notation for small magnitudes.
8. Spot-check a **normal-scale** variable (e.g. rates in the tens) to ensure labels still look reasonable.
9. Optional: `npm run build` then `npm start` for a production-like check.