### PR TITLE
Fix Explorer ZIP and tract tooltip labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Explorer map: Zip Code and tract hover tooltips now show the correct ZIP code and tract FIPS from `HEROP_ID` instead of a blank or invalid label ([#237](https://github.com/healthyregions/oeps/issues/237)).
+
 - Explorer map: legend bin labels and polygon hover tooltips use magnitude-aware numeric formatting so very small non-zero values are not shown as `0` ([#366](https://github.com/healthyregions/oeps/issues/366)).
 
 - Frictionless data package validation no longer fails when CSV foreign keys pointed at shapefile resources (`FileResource` / `row_stream`) ([#311](https://github.com/healthyregions/oeps/issues/311)).

--- a/explorer/_webgeoda/reducers/index.js
+++ b/explorer/_webgeoda/reducers/index.js
@@ -512,20 +512,25 @@ export default function reducer(state = INITIAL_STATE, action) {
         typeof action.payload.id === "number" ||
         typeof action.payload.id === "string"
       ) {
-        tooltipData = parseTooltipData(+action.payload.id, state, dataPresets);
-      } 
+        tooltipData = parseTooltipData(action.payload.id, state, dataPresets);
+      }
+
+      const hoverId =
+        action.payload.id === null || action.payload.id === undefined
+          ? null
+          : action.payload.id;
 
       const currentHoverTarget = {
         x: action.payload.x,
         y: action.payload.y,
         data: tooltipData,
-        id: +action.payload.id,
+        id: hoverId,
       };
       
       return {
         ...state,
         currentHoverTarget,
-        currentHoverId: action.payload.layer?.includes("tiles") ? null : +action.payload.id
+        currentHoverId: action.payload.layer?.includes("tiles") ? null : hoverId
       };
     }
     case "FORMAT_WIDGET_DATA": {

--- a/explorer/components/map/MainMap.js
+++ b/explorer/components/map/MainMap.js
@@ -146,7 +146,7 @@ export default function MainMap() {
           0,
           0,
           0,
-          255 * (+d.properties[currentId] === currentHoverId),
+          255 * (d.properties[currentId] === currentHoverId),
         ],
         // getElevation: d => currentMapData[d.properties.GEOID].height,
         pickable: true,
@@ -208,7 +208,7 @@ export default function MainMap() {
       <div className={styles.attribution}>
         <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener noreferrer">© Mapbox</a>
         <a href="https://www.openstreetmap.org/about/" target="_blank" rel="noopener noreferrer">© OpenStreetMap</a>
-        <a href="https://www.mapbox.com/contribute/#/?owner=csds-hiplab&id=ckmuv80qn2b6o17ltels6z7ub&access_token=pk.eyJ1IjoiY3Nkcy1oaXBsYWIiLCJhIjoiY2tkcTdlYXNsMGRhNDJybXl1MWdpejdidSJ9.mgK9yXDfhFCLh5YQuz6r_g&utm_source=https%3A%2F%2Fchichives.com%2F&utm_medium=attribution_link&utm_campaign=referrer" target="_blank" rel="noopener noreferrer">Improve this Map</a>
+        <a href={`https://www.mapbox.com/contribute/#/?owner=csds-hiplab&id=ckmuv80qn2b6o17ltels6z7ub&access_token=${process.env.NEXT_PUBLIC_MAPBOX_TOKEN}&utm_source=https%3A%2F%2Fchichives.com%2F&utm_medium=attribution_link&utm_campaign=referrer`} target="_blank" rel="noopener noreferrer">Improve this Map</a>
       </div>
     </div>
   );

--- a/explorer/components/map/MapTooltip.js
+++ b/explorer/components/map/MapTooltip.js
@@ -12,26 +12,37 @@ const formatTooltipValue = (value) => {
 
 const pad = (val, len, padChar) => `${val}`.length >= len ? ''+val : pad(`${padChar}${val}`, len, padChar)
 
+/** GEOID suffix from HEROP_ID (e.g. 860US61801 → 61801); passthrough for legacy numeric ids. */
+const geoidFromId = (id) => {
+  if (id === null || id === undefined || id === '') return null
+  const s = String(id)
+  if (/^\d{3}US/.test(s) && s.length > 5) return s.slice(5)
+  return s
+}
+
 const findTractStateAndCounty = ({countyDict, id}) => {
-  const idVal = pad(id, 11, 0)
-  const county = countyDict[+idVal.slice(0,5)]
+  const idVal = pad(geoidFromId(id), 11, 0)
+  const county = countyDict[+idVal.slice(0, 5)]
   return county?.Name + ' County, ' + county?.State
 }
 
 const TooltipTitle = ({currentData, stateDict, countyDict, id}) => {
   if (!currentData) return null
+  const geoid = geoidFromId(id)
   const text = currentData.includes('state')
-    ? stateDict[id]?.State
+    ? stateDict[geoid]?.State ?? stateDict[+geoid]?.State ?? stateDict[id]?.State
     : currentData.includes('count')
-    ? countyDict[id]?.Name + ', ' + countyDict[id]?.State
+    ? (countyDict[geoid]?.Name ?? countyDict[+geoid]?.Name ?? countyDict[id]?.Name) +
+      ', ' +
+      (countyDict[geoid]?.State ?? countyDict[+geoid]?.State ?? countyDict[id]?.State)
     : currentData.includes('Zip')
-    ? 'Zip Code: ' + pad(id, 5, 0)
+    ? 'Zip Code: ' + pad(geoid, 5, 0)
     : findTractStateAndCounty({countyDict, id})
-    
+
   if (text === undefined || (typeof text === 'string' && text.includes('undefined'))) return null
   return <span>
     <h2 className="tooltip-header">{text}</h2>
-    {currentData.includes('Tract') && <h4>Tract# {pad(id, 11, 0)}</h4>}
+    {currentData.includes('Tract') && <h4>Tract# {pad(geoid, 11, 0)}</h4>}
     </span>
 }
 


### PR DESCRIPTION
## Summary

- Fixes Explorer hover tooltips on **Zip Code** and **Tract** views showing blank, invalid, or `NaN` labels instead of the real geography id.
- Preserves `HEROP_ID` as a string in hover state (no numeric coercion).
- Parses ZIP codes and tract FIPS from `HEROP_ID` for tooltip headers (e.g. `860US60601` → `60601`).

<img width="2897" height="1629" alt="image" src="https://github.com/user-attachments/assets/cd922e4b-4036-45d8-bba2-41b192c80879" />

## Test plan

- [ ] Open Explorer map, select a variable available at ZIP level (e.g. FQHC distance).
- [ ] Switch to **Zip Codes**, zoom in, and hover a polygon — tooltip header shows **Zip Code: XXXXX** (5-digit ZIP).
- [ ] Switch to **Tracts**, hover a tract — tooltip shows county/state and **Tract#** with 11-digit FIPS.
- [ ] Confirm **States** and **Counties** tooltips still work as before.
- [ ] Confirm map hover highlight still works on geojson (non-tile) layers.

Closes #237