### PR TITLE
Strengthen validate-registry and fix MOUD map/registry alignment (#391)

### DIFF
--- a/.github/workflows/validate_registry.yml
+++ b/.github/workflows/validate_registry.yml
@@ -36,4 +36,4 @@ jobs:
         working-directory: backend
         env:
           FLASK_APP: oeps
-        run: flask validate-registry
+        run: flask validate-registry --check-columns --check-geography-rules --check-duplicate-titles

--- a/backend/oeps/commands/validate_registry.py
+++ b/backend/oeps/commands/validate_registry.py
@@ -2,6 +2,7 @@ import click
 from pathlib import Path
 
 from ..handlers import Registry
+from ..registry_validation import RegistryValidationError
 from ._common_opts import (
     add_common_opts,
     registry_opt,
@@ -16,8 +17,51 @@ from ._common_opts import (
     default=False,
     help="Updates all variable table_sources values directly from CSV data.",
 )
-def validate_registry(registry_path: Path, sync_table_sources: bool):
-    """Runs a series of validation processes against the current registry content."""
+@click.option(
+    "--check-columns",
+    is_flag=True,
+    default=False,
+    help="Fail if a variable table_sources entry has no matching column in that CSV.",
+)
+@click.option(
+    "--check-duplicate-titles",
+    is_flag=True,
+    default=False,
+    help="Report variables that share the same display title.",
+)
+@click.option(
+    "--duplicate-titles-as-error",
+    is_flag=True,
+    default=False,
+    help="Treat duplicate titles as errors (use with --check-duplicate-titles).",
+)
+@click.option(
+    "--check-geography-rules",
+    is_flag=True,
+    default=False,
+    help="Enforce MOUD/access geography rules for table_sources.",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Enable --check-columns, --check-duplicate-titles, and --check-geography-rules.",
+)
+def validate_registry(
+    registry_path: Path,
+    sync_table_sources: bool,
+    check_columns: bool,
+    check_duplicate_titles: bool,
+    duplicate_titles_as_error: bool,
+    check_geography_rules: bool,
+    strict: bool,
+):
+    """Runs validation processes against the current registry content."""
+
+    if strict:
+        check_columns = True
+        check_duplicate_titles = True
+        check_geography_rules = True
 
     registry = Registry.create_from_directory(registry_path)
     print(f"variables: {len(registry.variables)}")
@@ -25,7 +69,15 @@ def validate_registry(registry_path: Path, sync_table_sources: bool):
     print(f"geodata sources: {len(registry.geodata_sources)}")
     print(f"metadata entries: {len(registry.metadata)}")
 
-    registry.validate()
+    try:
+        registry.validate(
+            check_columns=check_columns,
+            check_duplicate_titles=check_duplicate_titles,
+            check_geography_rules=check_geography_rules,
+            duplicate_titles_as_error=duplicate_titles_as_error,
+        )
+    except RegistryValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     if sync_table_sources:
         registry.update_variable_table_sources()

--- a/backend/oeps/handlers.py
+++ b/backend/oeps/handlers.py
@@ -241,27 +241,39 @@ class Registry(BaseModel):
             theme_tree=theme_tree,
         )
 
-    def validate(self):
+    def validate(
+        self,
+        *,
+        check_columns: bool = False,
+        check_duplicate_titles: bool = False,
+        check_geography_rules: bool = False,
+        duplicate_titles_as_error: bool = False,
+    ):
+        from .registry_validation import (
+            RegistryValidationError,
+            print_validation_result,
+            run_registry_validation,
+        )
 
         print("\n-- checking variables...")
-        for k, v in self.variables.items():
-            if v.metadata not in self.metadata:
-                print(f"{k} | Invalid metadata name: {v.metadata} ")
-            for t in v.table_sources:
-                if t not in self.table_sources:
-                    print(f"{k} | Invalid table source name: {t} ")
-
         print("\n-- checking table sources...")
-        for k, v in self.table_sources.items():
-            if v.geodata_source not in self.geodata_sources:
-                print(f"{k} | Invalid geodata_source: {v.geodata_source} ")
-            pathpath = Path(v.full_path)
-            if pathpath.stem != v.name:
-                print(f"{k} | CSV file name must match table_source name: {pathpath.stem}")
-            if not pathpath.is_file():
-                print(f"{k} | CSV not found: {v.full_path}")
 
-        print("\nall checks complete.")
+        result = run_registry_validation(
+            self,
+            check_columns=check_columns,
+            check_duplicate_titles=check_duplicate_titles,
+            check_geography_rules=check_geography_rules,
+            duplicate_titles_as_error=duplicate_titles_as_error,
+        )
+        print_validation_result(result)
+
+        if result.ok:
+            print("\nall checks complete.")
+        else:
+            print(f"\nvalidation failed with {len(result.errors)} error(s).")
+            raise RegistryValidationError(
+                f"registry validation failed with {len(result.errors)} error(s)"
+            )
 
     def reload_variables(self):
         self.variables = self._load_variables(self.path)

--- a/backend/oeps/registry/variables/BupTmDr.json
+++ b/backend/oeps/registry/variables/BupTmDr.json
@@ -8,7 +8,6 @@
   "analysis": true,
   "metadata": "Access_MOUDs",
   "table_sources": [
-    "county-2025",
     "tract-2020",
     "tract-2025",
     "zcta-2020",

--- a/backend/oeps/registry/variables/BupTmDr2.json
+++ b/backend/oeps/registry/variables/BupTmDr2.json
@@ -8,6 +8,7 @@
   "analysis": true,
   "metadata": "Access_MOUDs",
   "table_sources": [
+    "tract-2025",
     "zcta-2025"
   ]
 }

--- a/backend/oeps/registry/variables/MetTmDr.json
+++ b/backend/oeps/registry/variables/MetTmDr.json
@@ -8,7 +8,6 @@
   "analysis": true,
   "metadata": "Access_MOUDs",
   "table_sources": [
-    "county-2025",
     "tract-2020",
     "tract-2025",
     "zcta-2020",

--- a/backend/oeps/registry/variables/MetTmDr2.json
+++ b/backend/oeps/registry/variables/MetTmDr2.json
@@ -8,6 +8,7 @@
   "analysis": true,
   "metadata": "Access_MOUDs",
   "table_sources": [
+    "tract-2025",
     "zcta-2025"
   ]
 }

--- a/backend/oeps/registry/variables/NaltTmDr.json
+++ b/backend/oeps/registry/variables/NaltTmDr.json
@@ -8,7 +8,6 @@
   "analysis": true,
   "metadata": "Access_MOUDs",
   "table_sources": [
-    "county-2025",
     "tract-2020",
     "tract-2025",
     "zcta-2020",

--- a/backend/oeps/registry/variables/NaltTmDr2.json
+++ b/backend/oeps/registry/variables/NaltTmDr2.json
@@ -8,6 +8,7 @@
   "analysis": false,
   "metadata": "Access_MOUDs",
   "table_sources": [
+    "tract-2025",
     "zcta-2025"
   ]
 }

--- a/backend/oeps/registry/variables/OtpTmDr2.json
+++ b/backend/oeps/registry/variables/OtpTmDr2.json
@@ -8,6 +8,7 @@
   "analysis": false,
   "metadata": "Access_MOUDs",
   "table_sources": [
+    "tract-2025",
     "zcta-2025"
   ]
 }

--- a/backend/oeps/registry_validation.py
+++ b/backend/oeps/registry_validation.py
@@ -38,6 +38,10 @@ def _table_summary_level(registry: Registry, table_source_name: str) -> str | No
     return gs.summary_level.name
 
 
+def _is_remote_table_path(path: str) -> bool:
+    return path.startswith("http://") or path.startswith("https://")
+
+
 def validate_registry_structure(registry: Registry) -> ValidationResult:
     """Checks that were previously print-only in Registry.validate()."""
     result = ValidationResult()
@@ -52,6 +56,8 @@ def validate_registry_structure(registry: Registry) -> ValidationResult:
     for k, v in registry.table_sources.items():
         if v.geodata_source not in registry.geodata_sources:
             result.errors.append(f"{k} | invalid geodata_source: {v.geodata_source}")
+        if _is_remote_table_path(v.full_path):
+            continue
         pathpath = Path(v.full_path)
         if pathpath.stem != v.name:
             result.errors.append(

--- a/backend/oeps/registry_validation.py
+++ b/backend/oeps/registry_validation.py
@@ -1,0 +1,198 @@
+"""Registry validation helpers for flask validate-registry."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .handlers import Registry
+
+POINT_TMDR_VARIABLES = frozenset({"MetTmDr", "BupTmDr", "NaltTmDr", "OtpTmDr"})
+IMPEDANCE_TMDR_VARIABLES = frozenset({"MetTmDr2", "BupTmDr2", "NaltTmDr2", "OtpTmDr2"})
+IMPEDANCE_TRACT_TABLE = "tract-2025"
+
+class RegistryValidationError(Exception):
+    """Raised when registry validation fails."""
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _table_summary_level(registry: Registry, table_source_name: str) -> str | None:
+    ts = registry.table_sources.get(table_source_name)
+    if not ts:
+        return None
+    gs = registry.geodata_sources.get(ts.geodata_source)
+    if not gs:
+        return None
+    return gs.summary_level.name
+
+
+def validate_registry_structure(registry: Registry) -> ValidationResult:
+    """Checks that were previously print-only in Registry.validate()."""
+    result = ValidationResult()
+
+    for k, v in registry.variables.items():
+        if v.metadata not in registry.metadata:
+            result.errors.append(f"{k} | invalid metadata name: {v.metadata}")
+        for t in v.table_sources:
+            if t not in registry.table_sources:
+                result.errors.append(f"{k} | invalid table source name: {t}")
+
+    for k, v in registry.table_sources.items():
+        if v.geodata_source not in registry.geodata_sources:
+            result.errors.append(f"{k} | invalid geodata_source: {v.geodata_source}")
+        pathpath = Path(v.full_path)
+        if pathpath.stem != v.name:
+            result.errors.append(
+                f"{k} | CSV file name must match table_source name: {pathpath.stem}"
+            )
+        if not pathpath.is_file():
+            result.errors.append(f"{k} | CSV not found: {v.full_path}")
+
+    return result
+
+
+def validate_registry_csv_columns(registry: Registry) -> ValidationResult:
+    """Every table_sources entry must have the variable column in that CSV."""
+    result = ValidationResult()
+    table_columns: dict[str, set[str]] = {}
+
+    for ts_name, ts in registry.table_sources.items():
+        pathpath = Path(ts.full_path)
+        if not pathpath.is_file():
+            continue
+        ts.load_dataframe()
+        table_columns[ts_name] = set(ts.df.columns)
+
+    for var_name, variable in registry.variables.items():
+        for ts_name in variable.table_sources:
+            cols = table_columns.get(ts_name)
+            if cols is None:
+                continue
+            if var_name not in cols:
+                result.errors.append(
+                    f"{var_name} | column missing from {ts_name} CSV "
+                    f"(listed in table_sources but not in file)"
+                )
+
+    return result
+
+
+def validate_duplicate_titles(registry: Registry) -> ValidationResult:
+    """Warn when multiple variables share the same display title."""
+    result = ValidationResult()
+    by_title: dict[str, list[str]] = defaultdict(list)
+    for name, variable in registry.variables.items():
+        by_title[variable.title].append(name)
+
+    for title, names in sorted(by_title.items()):
+        if len(names) > 1:
+            result.warnings.append(
+                f"duplicate title {title!r} | variables: {', '.join(sorted(names))}"
+            )
+
+    return result
+
+
+def validate_geography_rules(registry: Registry) -> ValidationResult:
+    """MOUD/access geography rules from issue #391."""
+    result = ValidationResult()
+    tract_cols: set[str] | None = None
+    tract_ts = registry.table_sources.get(IMPEDANCE_TRACT_TABLE)
+    if tract_ts and Path(tract_ts.full_path).is_file():
+        tract_ts.load_dataframe()
+        tract_cols = set(tract_ts.df.columns)
+
+    for var_name, variable in registry.variables.items():
+        if (
+            var_name in IMPEDANCE_TMDR_VARIABLES
+            and tract_cols is not None
+            and var_name in tract_cols
+            and IMPEDANCE_TRACT_TABLE not in variable.table_sources
+        ):
+            result.errors.append(
+                f"{var_name} | column exists in {IMPEDANCE_TRACT_TABLE} but "
+                f"{IMPEDANCE_TRACT_TABLE} is not in table_sources"
+            )
+
+        for ts_name in variable.table_sources:
+            level = _table_summary_level(registry, ts_name)
+            if not level:
+                continue
+
+            if var_name in POINT_TMDR_VARIABLES and level in {"state", "county"}:
+                result.errors.append(
+                    f"{var_name} | point-to-point driving time must not use "
+                    f"{ts_name} ({level} level); remove from table_sources"
+                )
+
+            if any(
+                marker in var_name
+                for marker in ("TmDrP", "CtTmDr")
+            ) and level in {"tract", "zcta"}:
+                result.errors.append(
+                    f"{var_name} | rollup variable must not use "
+                    f"{ts_name} ({level} level)"
+                )
+
+            if "AvTmDr" in var_name and level in {"tract", "zcta"}:
+                result.errors.append(
+                    f"{var_name} | average driving time must not use "
+                    f"{ts_name} ({level} level)"
+                )
+
+    return result
+
+
+def run_registry_validation(
+    registry: Registry,
+    *,
+    check_columns: bool = False,
+    check_duplicate_titles: bool = False,
+    check_geography_rules: bool = False,
+    duplicate_titles_as_error: bool = False,
+) -> ValidationResult:
+    combined = ValidationResult()
+
+    for partial in (
+        validate_registry_structure(registry),
+    ):
+        combined.errors.extend(partial.errors)
+        combined.warnings.extend(partial.warnings)
+
+    if check_columns:
+        partial = validate_registry_csv_columns(registry)
+        combined.errors.extend(partial.errors)
+        combined.warnings.extend(partial.warnings)
+
+    if check_duplicate_titles:
+        partial = validate_duplicate_titles(registry)
+        if duplicate_titles_as_error:
+            combined.errors.extend(partial.warnings)
+            partial.warnings = []
+        combined.warnings.extend(partial.warnings)
+
+    if check_geography_rules:
+        partial = validate_geography_rules(registry)
+        combined.errors.extend(partial.errors)
+        combined.warnings.extend(partial.warnings)
+
+    return combined
+
+
+def print_validation_result(result: ValidationResult) -> None:
+    for message in result.warnings:
+        print(f"WARNING: {message}")
+    for message in result.errors:
+        print(f"ERROR: {message}")

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -1,3 +1,11 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from oeps.registry_validation import RegistryValidationError
+
+
 def test_validate(runner):
     result = runner.invoke(
         args=[
@@ -7,3 +15,102 @@ def test_validate(runner):
         ]
     )
     assert result.exit_code == 0
+
+
+def test_validate_fails_on_invalid_metadata(runner, tmp_path):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    bad_var = registry_path / "variables" / "BadVar.json"
+    bad_var.write_text(
+        json.dumps(
+            {
+                "name": "BadVar",
+                "title": "Bad variable",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Not_A_Real_Metadata",
+                "table_sources": ["t-latest"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+            ]
+        )
+        assert result.exit_code != 0
+        assert "registry validation failed" in result.output.lower()
+    finally:
+        bad_var.unlink(missing_ok=True)
+
+
+def test_validate_geography_rules_point_tmdr(runner, tmp_path):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    met = registry_path / "variables" / "MetTmDr.json"
+    original = met.read_text(encoding="utf-8")
+    data = json.loads(original)
+    data["table_sources"] = list(data["table_sources"]) + ["c-2010"]
+    met.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-geography-rules",
+            ]
+        )
+        assert result.exit_code != 0
+    finally:
+        met.write_text(original, encoding="utf-8")
+
+
+def test_validate_fails_on_missing_csv_column(runner):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    bad_var = registry_path / "variables" / "BadColVar.json"
+    bad_var.write_text(
+        json.dumps(
+            {
+                "name": "BadColVar",
+                "title": "Bad column variable",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Demographic_Characteristics",
+                "table_sources": ["t-latest"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-columns",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "badcolvar" in result.output.lower()
+    finally:
+        bad_var.unlink(missing_ok=True)
+
+
+def test_registry_validation_error_is_raised():
+    from oeps.handlers import Registry
+
+    registry = Registry.create_from_directory(
+        Path(__file__).parent / "test_registry"
+    )
+    registry.variables["TotPop"].metadata = "missing"
+    with pytest.raises(RegistryValidationError):
+        registry.validate()

--- a/backend/tests/test_registry/csv/c-2010.csv
+++ b/backend/tests/test_registry/csv/c-2010.csv
@@ -1,0 +1,2 @@
+HEROP_ID,TotPop
+1,100

--- a/backend/tests/test_registry/csv/s-2000.csv
+++ b/backend/tests/test_registry/csv/s-2000.csv
@@ -1,0 +1,2 @@
+HEROP_ID,TotPop
+1,100

--- a/backend/tests/test_registry/csv/s-latest.csv
+++ b/backend/tests/test_registry/csv/s-latest.csv
@@ -1,0 +1,2 @@
+HEROP_ID,TotPop,ParkArea
+1,100,50

--- a/backend/tests/test_registry/csv/t-latest.csv
+++ b/backend/tests/test_registry/csv/t-latest.csv
@@ -1,0 +1,2 @@
+HEROP_ID,TotPop,MetTmDr
+1,100,10

--- a/backend/tests/test_registry/table_sources/c-2010.json
+++ b/backend/tests/test_registry/table_sources/c-2010.json
@@ -1,6 +1,6 @@
 {
     "name": "c-2010",
-    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/C_2010.csv",
+    "path": "../../tests/test_registry/csv/c-2010.csv",
     "format": "csv",
     "mediatype": "text/csv",
     "title": "OEPS Data Aggregated by County (2010)",

--- a/backend/tests/test_registry/table_sources/s-2000.json
+++ b/backend/tests/test_registry/table_sources/s-2000.json
@@ -1,6 +1,6 @@
 {
     "name": "s-2000",
-    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_2000.csv",
+    "path": "../../tests/test_registry/csv/s-2000.csv",
     "format": "csv",
     "mediatype": "text/csv",
     "title": "OEPS Data Aggregated by State (2000)",

--- a/backend/tests/test_registry/table_sources/s-latest.json
+++ b/backend/tests/test_registry/table_sources/s-latest.json
@@ -1,6 +1,6 @@
 {
     "name": "s-latest",
-    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/S_Latest.csv",
+    "path": "../../tests/test_registry/csv/s-latest.csv",
     "format": "csv",
     "mediatype": "text/csv",
     "title": "OEPS Data Aggregated by State (Latest)",

--- a/backend/tests/test_registry/table_sources/t-latest.json
+++ b/backend/tests/test_registry/table_sources/t-latest.json
@@ -1,6 +1,6 @@
 {
     "name": "t-latest",
-    "path": "https://raw.githubusercontent.com/GeoDaCenter/opioid-policy-scan/main/data_final/full_tables/T_Latest.csv",
+    "path": "../../tests/test_registry/csv/t-latest.csv",
     "format": "csv",
     "mediatype": "text/csv",
     "title": "OEPS Data Aggregated by Census Tract (latest)",

--- a/explorer/config/sources.json
+++ b/explorer/config/sources.json
@@ -11,143 +11,143 @@
         49.295128
       ],
       "tables": {
-        "state-2020": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_7870CE.csv",
+        "state-2017": {
+          "file": "_2BB018.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_27E3D3.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2025__county-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_34E25C.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_3A383E.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_9F13A9.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2022__county-2024": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_94E804.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_37026F.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023__county-2023__zcta-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_A841F0.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2022__county-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_8ADBC0.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_AAF3A6.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2017": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_486290.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_6417E5.csv",
+          "file": "_9AB60A.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2018__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_4BB1E9.csv",
+          "file": "_D36A61.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2020__county-2020": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_1CDB3F.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2024": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_53B1FB.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_90E27B.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_6BDC31.csv",
+        "state-2023__county-2023__zcta-2023__tract-2023": {
+          "file": "_184B47.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2021": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_B516E0.csv",
+          "file": "_216B77.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2025__county-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_906DC8.csv",
+        "state-2023": {
+          "file": "_9ABE76.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-providers-2010__county-providers-2010__tract-providers-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_EA98DB.csv",
+        "state-2023__county-2018__zcta-2018__tract-2018": {
+          "file": "_8134BE.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2020": {
+          "file": "_036B52.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2018__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_9A693B.csv",
+          "file": "_B8551A.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2023__county-2024": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_0A6CB3.csv",
+        "state-2025__county-2025": {
+          "file": "_DD760F.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2024__county-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_B37242.csv",
+        "state-2024": {
+          "file": "_14AD3C.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2022__county-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_A52AB1.csv",
+        "state-2018__county-2023__zcta-2023__tract-2023": {
+          "file": "_0FA187.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2021__county-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_0DA29F.csv",
+        "state-2023__county-2023__zcta-2023": {
+          "file": "_9E5200.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2022__county-2021": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_98D8B6.csv",
+        "state-2019": {
+          "file": "_DBE387.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-providers-2010__county-providers-2010__tract-sdoh-2014": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_DCBCBB.csv",
+          "file": "_632C8A.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018__county-2018__tract-2018": {
+          "file": "_0FF684.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2019__county-2019__zcta-2019__tract-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_3D7A33.csv",
+          "file": "_9099C3.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2021": {
+          "file": "_9270C3.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2020__county-2020": {
+          "file": "_0B61A8.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2022": {
+          "file": "_3CF395.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2021__county-2025": {
+          "file": "_95CE7B.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018": {
+          "file": "_5D76D7.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2025__county-2025__tract-2025": {
+          "file": "_1D26B3.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-providers-2010__county-providers-2010__tract-providers-2010": {
+          "file": "_E99C05.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2024": {
+          "file": "_E0A9C6.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2023__county-2024": {
+          "file": "_59D06B.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2019": {
+          "file": "_D9FF68.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2024__county-2019": {
+          "file": "_561C5C.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         }
@@ -165,168 +165,163 @@
         49.295128
       ],
       "tables": {
-        "county-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_44194C.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2025__county-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_1B867C.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2020": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_3D74D4.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2022__county-2024": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_B1F5C9.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2020__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_E3CCDA.csv",
+        "state-2018__county-2018__zcta-2018__tract-2018": {
+          "file": "_64354D.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_D59705.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023__county-2023__zcta-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_6F1E77.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2015": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_782F4E.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2022__county-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_A96D17.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_7733F2.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_4FB4BE.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_1759EB.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_58A6D5.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_124354.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2022__zcta-2022__tract-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_9E0A4E.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2020__county-2020": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_AC90E7.csv",
+          "file": "_C5D773.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_A6204D.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_ED68D2.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2025__county-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_49EA50.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-providers-2010__county-providers-2010__tract-providers-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_C89F29.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_572661.csv",
+          "file": "_7F825B.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2018__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_EEB7B9.csv",
+          "file": "_83D45B.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2023__county-2024": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_D24B7E.csv",
+        "county-2020": {
+          "file": "_15ACCE.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2024__county-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_56E150.csv",
+        "state-2025__county-2025": {
+          "file": "_0EEA9C.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025": {
+          "file": "_29EFE8.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025__zcta-2020__tract-2025": {
+          "file": "_9D322D.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "county-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_025079.csv",
+          "file": "_EFA0B7.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2022__county-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_D3337D.csv",
+        "county-2023__zcta-2023__tract-2023": {
+          "file": "_D5F0A6.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "state-2021__county-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_DAD9D1.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2022__county-2021": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_F9DD2A.csv",
+        "state-2018__county-2023__zcta-2023__tract-2023": {
+          "file": "_ED9288.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "county-2000": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_C5AB02.csv",
+          "file": "_CA6FD4.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "county-providers-2010__tract-providers-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_E031A0.csv",
+        "county-2015": {
+          "file": "_79F174.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2023__county-2023__zcta-2023": {
+          "file": "_1B157E.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-providers-2010__county-providers-2010__tract-sdoh-2014": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_6C3D84.csv",
+          "file": "_6A7662.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018__county-2018__tract-2018": {
+          "file": "_781000.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2019__county-2019__zcta-2019__tract-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_50FDE1.csv",
+          "file": "_DC1137.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2021": {
+          "file": "_CE88FA.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2020__county-2020": {
+          "file": "_19A703.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2022": {
+          "file": "_AD8911.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2021__county-2025": {
+          "file": "_2CCAE8.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-providers-2010__tract-providers-2010": {
+          "file": "_BD26C2.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "county-2017": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_51E826.csv",
+          "file": "_68B1AD.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2023": {
+          "file": "_1502D3.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2022__zcta-2022__tract-2022": {
+          "file": "_D1E5F5.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025__tract-2025": {
+          "file": "_1CABF1.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2025__county-2025__tract-2025": {
+          "file": "_A17060.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-providers-2010__county-providers-2010__tract-providers-2010": {
+          "file": "_C34BB1.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2024": {
+          "file": "_9C4F3C.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2023__county-2024": {
+          "file": "_B58541.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2022__county-2019": {
+          "file": "_EB45F8.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2024__county-2019": {
+          "file": "_2127B7.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         }
@@ -345,83 +340,73 @@
         49.295128
       ],
       "tables": {
-        "zcta-ruca-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_11AC01.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-2020__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_A6D1E4.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_0FAC84.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2020__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_62FAEB.csv",
+        "state-2018__county-2018__zcta-2018__tract-2018": {
+          "file": "_67169D.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_9BF109.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2023__county-2023__zcta-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_5019B5.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_95E283.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_DF96A4.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_795FED.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-ruca-2010__tract-ruca-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_E599C9.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2022__zcta-2022__tract-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_6261BE.csv",
+          "file": "_487E56.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_2B9D49.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_CB33E8.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_72E37E.csv",
+          "file": "_B54CAA.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2018__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_95EF6B.csv",
+          "file": "_C132F5.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "zcta-2020__tract-2025": {
+          "file": "_206A57.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "zcta-2025__tract-2025": {
+          "file": "_B279E6.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025__zcta-2020__tract-2025": {
+          "file": "_E8D6D9.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2023__zcta-2023__tract-2023": {
+          "file": "_198F30.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018__county-2023__zcta-2023__tract-2023": {
+          "file": "_E9551C.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2023__county-2023__zcta-2023": {
+          "file": "_044097.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2019__county-2019__zcta-2019__tract-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_348102.csv",
+          "file": "_EC0EC8.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "zcta-ruca-2010__tract-ruca-2010": {
+          "file": "_ABFCC5.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2022__zcta-2022__tract-2022": {
+          "file": "_EBE832.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "zcta-ruca-2010": {
+          "file": "_43D2E9.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         }
@@ -440,118 +425,113 @@
         49.295128
       ],
       "tables": {
-        "tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_C60293.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-2020__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_3148C7.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_354A57.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2020__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_11D827.csv",
+        "state-2018__county-2018__zcta-2018__tract-2018": {
+          "file": "_27F654.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_D92F29.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_B4C787.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2023__zcta-2023__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_B2C56B.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "tract-sdoh-2014": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_74E8CD.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_E7FD84.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_104274.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2018__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_8329DC.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "zcta-ruca-2010__tract-ruca-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_BFDEC0.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2022__zcta-2022__tract-2022": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_C8F30D.csv",
+          "file": "_E0573C.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2018__zcta-2018__tract-2018": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_1F8109.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "tract-2020": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_ECB25B.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-2025__county-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_47B9BA.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "state-providers-2010__county-providers-2010__tract-providers-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_300DA6.csv",
-          "type": "characteristic",
-          "join": "HEROP_ID"
-        },
-        "county-2025__zcta-2025__tract-2025": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_D33654.csv",
+          "file": "_E1AD92.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2023__county-2023__zcta-2018__tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_3A6B77.csv",
+          "file": "_2E767F.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "tract-2023": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_2ED19D.csv",
+        "zcta-2020__tract-2025": {
+          "file": "_4F005F.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
-        "county-providers-2010__tract-providers-2010": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_FE5D78.csv",
+        "zcta-2025__tract-2025": {
+          "file": "_02507D.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "tract-2025": {
+          "file": "_3DDE54.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "tract-2020": {
+          "file": "_5D986B.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025__zcta-2020__tract-2025": {
+          "file": "_91FE71.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2023__zcta-2023__tract-2023": {
+          "file": "_24E181.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018__county-2023__zcta-2023__tract-2023": {
+          "file": "_2491B9.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-providers-2010__county-providers-2010__tract-sdoh-2014": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_709DA6.csv",
+          "file": "_D76EDF.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2018__county-2018__tract-2018": {
+          "file": "_5A684B.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "tract-2023": {
+          "file": "_E79D14.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "tract-sdoh-2014": {
+          "file": "_360B76.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         },
         "state-2019__county-2019__zcta-2019__tract-2019": {
-          "file": "https://herop-geodata.s3.us-east-2.amazonaws.com/explorer/csvs/_F2E769.csv",
+          "file": "_6894AE.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-providers-2010__tract-providers-2010": {
+          "file": "_0A7270.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "zcta-ruca-2010__tract-ruca-2010": {
+          "file": "_534DE2.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2022__zcta-2022__tract-2022": {
+          "file": "_F138FC.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "county-2025__tract-2025": {
+          "file": "_942C57.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-2025__county-2025__tract-2025": {
+          "file": "_B14142.csv",
+          "type": "characteristic",
+          "join": "HEROP_ID"
+        },
+        "state-providers-2010__county-providers-2010__tract-providers-2010": {
+          "file": "_400168.csv",
           "type": "characteristic",
           "join": "HEROP_ID"
         }

--- a/explorer/config/variables.json
+++ b/explorer/config/variables.json
@@ -268,21 +268,14 @@
   {
     "variable": "% Population: Age 15-44",
     "numerator": "state-2018__county-2018__zcta-2018__tract-2018",
-    "nProperty": "Age15_44P",
+    "nProperty": "Age15_44",
     "theme": "Social",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
   },
   {
     "variable": "% Population: Age 15-44",
     "numerator": "state-2018__county-2018__zcta-2018__tract-2018",
-    "nProperty": "Age15_44",
-    "theme": "Social",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
-  },
-  {
-    "variable": "% Population: Age 65+",
-    "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
-    "nProperty": "Ovr65P",
+    "nProperty": "Age15_44P",
     "theme": "Social",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
   },
@@ -290,6 +283,13 @@
     "variable": "% Population: Age 65+",
     "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
     "nProperty": "Ovr65",
+    "theme": "Social",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
+  },
+  {
+    "variable": "% Population: Age 65+",
+    "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
+    "nProperty": "Ovr65P",
     "theme": "Social",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
   },
@@ -540,15 +540,15 @@
   },
   {
     "variable": "% tracts with Substance Use Treatment program (30-min drive)",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "SutTmDrP",
+    "numerator": "state-2020__county-2020",
+    "nProperty": "SutpTmDrP",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
   {
     "variable": "% tracts with Substance Use Treatment program (30-min drive)",
-    "numerator": "state-2020__county-2020",
-    "nProperty": "SutpTmDrP",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "SutTmDrP",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
@@ -1366,7 +1366,7 @@
   },
   {
     "variable": "Driving Time (min) to nearest Buprenorphine Provider",
-    "numerator": "county-2025__zcta-2025__tract-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "BupTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
@@ -1387,22 +1387,15 @@
   },
   {
     "variable": "Driving Time (min) to nearest Methadone Provider",
-    "numerator": "county-2025__zcta-2025__tract-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "MetTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
     "variable": "Driving Time (min) to nearest Naltrexone Provider",
-    "numerator": "county-2025__zcta-2025__tract-2025",
-    "nProperty": "NaltTmDr",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
     "numerator": "zcta-2025__tract-2025",
-    "nProperty": "OtpTmDr",
+    "nProperty": "NaltTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
@@ -1410,6 +1403,13 @@
     "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
     "numerator": "state-2025__county-2025",
     "nProperty": "OtpAvTmDr",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
+    "numerator": "zcta-2025__tract-2025",
+    "nProperty": "OtpTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
@@ -1429,15 +1429,15 @@
   },
   {
     "variable": "Driving Time (min) to nearest Substance Use Treatment program",
-    "numerator": "state-2020__county-2020",
-    "nProperty": "SutpAvTmDr",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "SutAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
   {
     "variable": "Driving Time (min) to nearest Substance Use Treatment program",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "SutAvTmDr",
+    "numerator": "state-2020__county-2020",
+    "nProperty": "SutpAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
@@ -1534,7 +1534,7 @@
   },
   {
     "variable": "Driving time to nearest OTP (impedance-adjusted)",
-    "numerator": "zcta-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "OtpTmDr2",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
@@ -1555,21 +1555,21 @@
   },
   {
     "variable": "Driving time to nearest buprenorphine provider (with impedance)",
-    "numerator": "zcta-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "BupTmDr2",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
     "variable": "Driving time to nearest methadone provider (with impedance)",
-    "numerator": "zcta-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "MetTmDr2",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
     "variable": "Driving time to nearest naltrexone provider (with impedance)",
-    "numerator": "zcta-2025",
+    "numerator": "zcta-2025__tract-2025",
     "nProperty": "NaltTmDr2",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"


### PR DESCRIPTION
## Summary

- Add `registry_validation.py` with structural checks (hard errors), CSV column sync, duplicate-title warnings, and MOUD geography rules for `*TmDr` / `*TmDr2` / rollup variables
- Refactor `Registry.validate()` and `flask validate-registry` to raise on failure; add `--check-columns`, `--check-duplicate-titles`, `--check-geography-rules`, and `--strict`
- **Phase 0 registry fixes:** remove `county-2025` from `MetTmDr`, `BupTmDr`, `NaltTmDr`; add `tract-2025` to `MetTmDr2`, `BupTmDr2`, `NaltTmDr2`, `OtpTmDr2`
- Rebuild explorer config (`sources.json`, `variables.json`) so tract impedance vars and point-to-point MOUD numerators match registry
- Extend `test_registry.py` with failure cases; enable stricter checks in CI **Validate registry** workflow
- Add PR template checklist for registry/data changes (map spot-check, `validate-registry`, `build-explorer`)

## Not in this PR (follow-up per #391)

- `*TmDrP` state rollups or county-only enforcement
- Removing stale `*TmDr` columns from `county-2025.csv`
- Rollup sanity checks (Phase 4), `merge-csv` safety (Phase 5), explorer drift CI (Phase 7)
- Duplicate display titles remain **warnings** until #390

## Test plan

- [x] `flask validate-registry --strict` passes locally (8 duplicate-title warnings expected)
- [x] `flask build-explorer --map-only` run; explorer config updated
- [x] CI **Validate registry** workflow passes on this PR
- [x] CI `pytest tests/test_registry.py` passes
- [x] Map spot-check after deploy:
  - [x] `OtpTmDr` + Tracts → `zcta-2025__tract-2025`
  - [x] `MetTmDr` + Tracts → `zcta-2025__tract-2025` (no county-only view)
  - [x] `MetTmDr2` + Tracts → includes `tract-2025`
  - [x] `MetTmDrP` + Counties → `county-2025`