### PR TITLE
Disambiguate duplicate map variable titles 

### DIFF
--- a/.github/workflows/validate_registry.yml
+++ b/.github/workflows/validate_registry.yml
@@ -36,4 +36,4 @@ jobs:
         working-directory: backend
         env:
           FLASK_APP: oeps
-        run: flask validate-registry --check-columns --check-geography-rules --check-duplicate-titles
+        run: flask validate-registry --check-columns --check-geography-rules --check-duplicate-titles --duplicate-titles-as-error

--- a/backend/oeps/registry/variables/Age15_44.json
+++ b/backend/oeps/registry/variables/Age15_44.json
@@ -1,6 +1,6 @@
 {
   "name": "Age15_44",
-  "title": "% Population: Age 15-44",
+  "title": "Population: Age 15-44 (count)",
   "type": "integer",
   "example": "784568",
   "description": "Total population between age 15-44",

--- a/backend/oeps/registry/variables/Age15_44P.json
+++ b/backend/oeps/registry/variables/Age15_44P.json
@@ -1,6 +1,6 @@
 {
   "name": "Age15_44P",
-  "title": "% Population: Age 15-44",
+  "title": "% Population: Age 15-44 (percent)",
   "type": "number",
   "example": "60.43",
   "description": "Percentage of population below 45 years of age",

--- a/backend/oeps/registry/variables/BupAvTmBk.json
+++ b/backend/oeps/registry/variables/BupAvTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "BupAvTmBk",
-  "title": "Biking Time (min) to Nearest Buprenorphine Provider",
+  "title": "Biking Time (min) to nearest Buprenorphine Provider (state/county average)",
   "type": "number",
   "example": "1.12569444444444",
   "description": "Average biking time (minutes) across tracts in county to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/BupAvTmDr.json
+++ b/backend/oeps/registry/variables/BupAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "BupAvTmDr",
-  "title": "Driving Time (min) to Nearest Buprenorphine Provider",
+  "title": "Driving Time (min) to nearest Buprenorphine Provider (state/county average)",
   "type": "number",
   "example": "0.42",
   "description": "Average driving time (minutes) across tracts in county to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/BupAvTmWk.json
+++ b/backend/oeps/registry/variables/BupAvTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "BupAvTmWk",
-  "title": "Walking Time (min) to Nearest Buprenorphine Provider",
+  "title": "Walking Time (min) to nearest Buprenorphine Provider (state/county average)",
   "type": "number",
   "example": "1.87725694444444",
   "description": "Average walking time (minutes) across tracts in county to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/BupTmBk.json
+++ b/backend/oeps/registry/variables/BupTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "BupTmBk",
-  "title": "Biking Time (min) to nearest Buprenorphine Provider",
+  "title": "Biking Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
   "type": "number",
   "example": "0",
   "description": "Biking time (minutes) to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/BupTmDr.json
+++ b/backend/oeps/registry/variables/BupTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "BupTmDr",
-  "title": "Driving Time (min) to nearest Buprenorphine Provider",
+  "title": "Driving Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
   "type": "number",
   "example": "10.12",
   "description": "Driving time (minutes) to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/BupTmWk.json
+++ b/backend/oeps/registry/variables/BupTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "BupTmWk",
-  "title": "Walking Time (min) to nearest Buprenorphine Provider",
+  "title": "Walking Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
   "type": "number",
   "example": "0",
   "description": "Walking time (minutes) to nearest buprenorphine provider",

--- a/backend/oeps/registry/variables/HospAvTmDrP2.json
+++ b/backend/oeps/registry/variables/HospAvTmDrP2.json
@@ -1,6 +1,6 @@
 {
   "name": "HospAvTmDrP2",
-  "title": "Avg. Driving Time to nearest Hospital",
+  "title": "Avg. Driving Time to nearest Hospital (with impedance factor)",
   "type": "number",
   "example": "33.33",
   "description": "Average driving time (minutes) across tracts in state to nearest hospital with Impedance factor",

--- a/backend/oeps/registry/variables/MetAvTmBk.json
+++ b/backend/oeps/registry/variables/MetAvTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "MetAvTmBk",
-  "title": "Biking Time (min) to Nearest Methadone Provider",
+  "title": "Biking Time (min) to nearest Methadone Provider (state/county average)",
   "type": "number",
   "example": "6.32958333333333",
   "description": "Average biking time (minutes) across tracts in county to nearest methadone provider",

--- a/backend/oeps/registry/variables/MetAvTmDr.json
+++ b/backend/oeps/registry/variables/MetAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "MetAvTmDr",
-  "title": "Driving Time (min) to Nearest Methadone Provider",
+  "title": "Driving Time (min) to nearest Methadone Provider (state/county average)",
   "type": "number",
   "example": "2.6",
   "description": "Average driving time (minutes) across tracts in county to nearest methadone provider",

--- a/backend/oeps/registry/variables/MetAvTmWk.json
+++ b/backend/oeps/registry/variables/MetAvTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "MetAvTmWk",
-  "title": "Walking Time (min) to Nearest Methadone Provide",
+  "title": "Walking Time (min) to nearest Methadone Provider (state/county average)",
   "type": "number",
   "example": "13.7240277777778",
   "description": "Average walking time (minutes) across tracts in county to nearest methadone provider",

--- a/backend/oeps/registry/variables/MetTmBk.json
+++ b/backend/oeps/registry/variables/MetTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "MetTmBk",
-  "title": "Biking Time (min) to nearest Methadone Provider",
+  "title": "Biking Time (min) to nearest Methadone Provider (tract/ZIP)",
   "type": "number",
   "example": "148.18",
   "description": "Biking time (minutes) to nearest methadone provider",

--- a/backend/oeps/registry/variables/MetTmDr.json
+++ b/backend/oeps/registry/variables/MetTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "MetTmDr",
-  "title": "Driving Time (min) to nearest Methadone Provider",
+  "title": "Driving Time (min) to nearest Methadone Provider (tract/ZIP)",
   "type": "number",
   "example": "27.39",
   "description": "Driving time (minutes) to nearest methadone provider",

--- a/backend/oeps/registry/variables/MetTmWk.json
+++ b/backend/oeps/registry/variables/MetTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "MetTmWk",
-  "title": "Walking Time (min) to nearest Methadone Provider",
+  "title": "Walking Time (min) to nearest Methadone Provider (tract/ZIP)",
   "type": "number",
   "example": "1744.66",
   "description": "Walking time (minutes) to nearest methadone provider",

--- a/backend/oeps/registry/variables/MhAvTmDr.json
+++ b/backend/oeps/registry/variables/MhAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "MhAvTmDr",
-  "title": "Driving Time (min) to nearest Mental Health Provider",
+  "title": "Driving Time (min) to nearest Mental Health Provider (state/county average)",
   "type": "number",
   "example": "11.42",
   "description": "Average driving time (minutes) across tracts in state to nearest mental health provider",

--- a/backend/oeps/registry/variables/MhTmDr.json
+++ b/backend/oeps/registry/variables/MhTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "MhTmDr",
-  "title": "Driving Time (min) to nearest Mental Health Provider",
+  "title": "Driving Time (min) to nearest Mental Health Provider (tract/ZIP)",
   "type": "number",
   "example": "0",
   "description": "Driving time from tract/zip origin centroid to the nearest tract/zip mental health provider destination centroid, in minutes",

--- a/backend/oeps/registry/variables/NaltAvTmBk.json
+++ b/backend/oeps/registry/variables/NaltAvTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltAvTmBk",
-  "title": "Biking Time (min) to Nearest Naltrexone Provider",
+  "title": "Biking Time (min) to nearest Naltrexone Provider (state/county average)",
   "type": "number",
   "example": "3.80180555555556",
   "description": "Average biking time (minutes) across tracts in county to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/NaltAvTmDr.json
+++ b/backend/oeps/registry/variables/NaltAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltAvTmDr",
-  "title": "Driving Time (min) to Nearest Naltrexone Provider",
+  "title": "Driving Time (min) to nearest Naltrexone Provider (state/county average)",
   "type": "number",
   "example": "1.61",
   "description": "Average driving time (minutes) across tracts in county to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/NaltAvTmWk.json
+++ b/backend/oeps/registry/variables/NaltAvTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltAvTmWk",
-  "title": "Walking Time (min) to Nearest Naltrexone Provider",
+  "title": "Walking Time (min) to nearest Naltrexone Provider (state/county average)",
   "type": "number",
   "example": "7.40684027777778",
   "description": "Average walking time (minutes) across tracts in county to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/NaltTmBk.json
+++ b/backend/oeps/registry/variables/NaltTmBk.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltTmBk",
-  "title": "Biking Time (min) to nearest Naltrexone Provider",
+  "title": "Biking Time (min) to nearest Naltrexone Provider (tract/ZIP)",
   "type": "number",
   "example": "165.18",
   "description": "Biking time (minutes) to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/NaltTmDr.json
+++ b/backend/oeps/registry/variables/NaltTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltTmDr",
-  "title": "Driving Time (min) to nearest Naltrexone Provider",
+  "title": "Driving Time (min) to nearest Naltrexone Provider (tract/ZIP)",
   "type": "number",
   "example": "35.34",
   "description": "Driving time (minutes) to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/NaltTmWk.json
+++ b/backend/oeps/registry/variables/NaltTmWk.json
@@ -1,6 +1,6 @@
 {
   "name": "NaltTmWk",
-  "title": "Walking Time (min) to nearest Naltrexone Provider",
+  "title": "Walking Time (min) to nearest Naltrexone Provider (tract/ZIP)",
   "type": "number",
   "example": "",
   "description": "Walking time (minutes) to nearest naltrexone provider",

--- a/backend/oeps/registry/variables/OtpAvTmDr.json
+++ b/backend/oeps/registry/variables/OtpAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "OtpAvTmDr",
-  "title": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
+  "title": "Driving Time (min) to nearest Opioid Treatment Program (OTP) (state/county average)",
   "type": "number",
   "example": "24.18",
   "description": "Average driving time (minutes) across tracts to nearest opioid treatment program.",

--- a/backend/oeps/registry/variables/OtpTmDr.json
+++ b/backend/oeps/registry/variables/OtpTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "OtpTmDr",
-  "title": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
+  "title": "Driving Time (min) to nearest Opioid Treatment Program (OTP) (tract/ZIP)",
   "type": "number",
   "example": "27.39",
   "description": "Driving time from tract/zip origin centroid to the nearest tract/zip OTP destination centroid, in minutes",

--- a/backend/oeps/registry/variables/Ovr65.json
+++ b/backend/oeps/registry/variables/Ovr65.json
@@ -1,6 +1,6 @@
 {
   "name": "Ovr65",
-  "title": "% Population: Age 65+",
+  "title": "Population: Age 65+ (count)",
   "type": "number",
   "example": "11.24",
   "description": "Percentage of population between ages of 15 & 24",

--- a/backend/oeps/registry/variables/Ovr65P.json
+++ b/backend/oeps/registry/variables/Ovr65P.json
@@ -1,6 +1,6 @@
 {
   "name": "Ovr65P",
-  "title": "% Population: Age 65+",
+  "title": "% Population: Age 65+ (percent)",
   "type": "number",
   "example": "15.77",
   "description": "Percentage of population over 65",

--- a/backend/oeps/registry/variables/SutAvTmDr.json
+++ b/backend/oeps/registry/variables/SutAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "SutAvTmDr",
-  "title": "Driving Time (min) to nearest Substance Use Treatment program",
+  "title": "Driving Time (min) to nearest Substance Use Treatment program (2025)",
   "type": "number",
   "example": "50.48",
   "description": "Average driving time (minutes) across tracts in state to nearest Substance Use Treatment program.",

--- a/backend/oeps/registry/variables/SutCtTmDr.json
+++ b/backend/oeps/registry/variables/SutCtTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "SutCtTmDr",
-  "title": "Tracts with Substance Use Treatment (SUT) program (30-min drive)",
+  "title": "Tracts with Substance Use Treatment (SUT) program (30-min drive) (2025)",
   "type": "integer",
   "example": "48",
   "description": "Number of tracts with Substance Use Treatment within a 30-min driving range.",

--- a/backend/oeps/registry/variables/SutTmDrP.json
+++ b/backend/oeps/registry/variables/SutTmDrP.json
@@ -1,6 +1,6 @@
 {
   "name": "SutTmDrP",
-  "title": "% tracts with Substance Use Treatment program (30-min drive)",
+  "title": "% tracts with Substance Use Treatment program (30-min drive) (2025)",
   "type": "number",
   "example": "3.34",
   "description": "Percent of tracts with Substance Use Treatment program within a 30-minute driving range.",

--- a/backend/oeps/registry/variables/SutpAvTmDr.json
+++ b/backend/oeps/registry/variables/SutpAvTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "SutpAvTmDr",
-  "title": "Driving Time (min) to nearest Substance Use Treatment program",
+  "title": "Driving Time (min) to nearest Substance Use Treatment program (2020)",
   "type": "number",
   "example": "9.96",
   "description": "Average driving time (minutes) across tracts in state to nearest Substance Use Treatment program.",

--- a/backend/oeps/registry/variables/SutpCtTmDr.json
+++ b/backend/oeps/registry/variables/SutpCtTmDr.json
@@ -1,6 +1,6 @@
 {
   "name": "SutpCtTmDr",
-  "title": "Tracts with Substance Use Treatment (SUT) program (30-min drive)",
+  "title": "Tracts with Substance Use Treatment (SUT) program (30-min drive) (2020)",
   "type": "integer",
   "example": "1364",
   "description": "Number of tracts with Substance Use Treatment within a 30-min driving range.",

--- a/backend/oeps/registry/variables/SutpTmDrP.json
+++ b/backend/oeps/registry/variables/SutpTmDrP.json
@@ -1,6 +1,6 @@
 {
   "name": "SutpTmDrP",
-  "title": "% tracts with Substance Use Treatment program (30-min drive)",
+  "title": "% tracts with Substance Use Treatment program (30-min drive) (2020)",
   "type": "number",
   "example": "0.94",
   "description": "Percent of tracts with Substance Use Treatment program within a 30-minute driving range.",

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -105,6 +105,41 @@ def test_validate_fails_on_missing_csv_column(runner):
         bad_var.unlink(missing_ok=True)
 
 
+def test_validate_fails_on_duplicate_titles(runner):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    dup_var = registry_path / "variables" / "DupTitleVar.json"
+    dup_var.write_text(
+        json.dumps(
+            {
+                "name": "DupTitleVar",
+                "title": "TotPop",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Demographic_Characteristics",
+                "table_sources": ["t-latest"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-duplicate-titles",
+                "--duplicate-titles-as-error",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "duplicate title" in result.output.lower()
+    finally:
+        dup_var.unlink(missing_ok=True)
+
+
 def test_registry_validation_error_is_raised():
     from oeps.handlers import Registry
 

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -112,7 +112,7 @@ def test_validate_fails_on_duplicate_titles(runner):
         json.dumps(
             {
                 "name": "DupTitleVar",
-                "title": "TotPop",
+                "title": "Total Population",
                 "type": "number",
                 "example": "1",
                 "description": "test",

--- a/explorer/config/variables.json
+++ b/explorer/config/variables.json
@@ -266,30 +266,16 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Race_Ethnicity.md"
   },
   {
-    "variable": "% Population: Age 15-44",
+    "variable": "% Population: Age 15-44 (percent)",
     "numerator": "state-2018__county-2018__zcta-2018__tract-2018",
     "nProperty": "Age15_44P",
     "theme": "Social",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
   },
   {
-    "variable": "% Population: Age 15-44",
-    "numerator": "state-2018__county-2018__zcta-2018__tract-2018",
-    "nProperty": "Age15_44",
-    "theme": "Social",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
-  },
-  {
-    "variable": "% Population: Age 65+",
+    "variable": "% Population: Age 65+ (percent)",
     "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
     "nProperty": "Ovr65P",
-    "theme": "Social",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
-  },
-  {
-    "variable": "% Population: Age 65+",
-    "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
-    "nProperty": "Ovr65",
     "theme": "Social",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
   },
@@ -539,16 +525,16 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Pharmacies.md"
   },
   {
-    "variable": "% tracts with Substance Use Treatment program (30-min drive)",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "SutTmDrP",
+    "variable": "% tracts with Substance Use Treatment program (30-min drive) (2020)",
+    "numerator": "state-2020__county-2020",
+    "nProperty": "SutpTmDrP",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
   {
-    "variable": "% tracts with Substance Use Treatment program (30-min drive)",
-    "numerator": "state-2020__county-2020",
-    "nProperty": "SutpTmDrP",
+    "variable": "% tracts with Substance Use Treatment program (30-min drive) (2025)",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "SutTmDrP",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
@@ -770,42 +756,42 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Mental_Health.md"
   },
   {
-    "variable": "Biking Time (min) to Nearest Buprenorphine Provider",
+    "variable": "Biking Time (min) to nearest Buprenorphine Provider (state/county average)",
     "numerator": "county-2020",
     "nProperty": "BupAvTmBk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Biking Time (min) to Nearest Methadone Provider",
-    "numerator": "county-2020",
-    "nProperty": "MetAvTmBk",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Biking Time (min) to Nearest Naltrexone Provider",
-    "numerator": "county-2020",
-    "nProperty": "NaltAvTmBk",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Biking Time (min) to nearest Buprenorphine Provider",
+    "variable": "Biking Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "BupTmBk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Biking Time (min) to nearest Methadone Provider",
+    "variable": "Biking Time (min) to nearest Methadone Provider (state/county average)",
+    "numerator": "county-2020",
+    "nProperty": "MetAvTmBk",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Biking Time (min) to nearest Methadone Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "MetTmBk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Biking Time (min) to nearest Naltrexone Provider",
+    "variable": "Biking Time (min) to nearest Naltrexone Provider (state/county average)",
+    "numerator": "county-2020",
+    "nProperty": "NaltAvTmBk",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Biking Time (min) to nearest Naltrexone Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "NaltTmBk",
     "theme": "Environment",
@@ -1344,72 +1330,72 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Syringe_Policy.md"
   },
   {
-    "variable": "Driving Time (min) to Nearest Buprenorphine Provider",
+    "variable": "Driving Time (min) to nearest Buprenorphine Provider (state/county average)",
     "numerator": "state-2025__county-2025",
     "nProperty": "BupAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Driving Time (min) to Nearest Methadone Provider",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "MetAvTmDr",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Driving Time (min) to Nearest Naltrexone Provider",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "NaltAvTmDr",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Driving Time (min) to nearest Buprenorphine Provider",
+    "variable": "Driving Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
     "numerator": "zcta-2025__tract-2025",
     "nProperty": "BupTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Mental Health Provider",
+    "variable": "Driving Time (min) to nearest Mental Health Provider (state/county average)",
     "numerator": "state-2025__county-2025",
     "nProperty": "MhAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Mental_Health.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Mental Health Provider",
+    "variable": "Driving Time (min) to nearest Mental Health Provider (tract/ZIP)",
     "numerator": "zcta-2025__tract-2025",
     "nProperty": "MhTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Mental_Health.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Methadone Provider",
+    "variable": "Driving Time (min) to nearest Methadone Provider (state/county average)",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "MetAvTmDr",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Driving Time (min) to nearest Methadone Provider (tract/ZIP)",
     "numerator": "zcta-2025__tract-2025",
     "nProperty": "MetTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Naltrexone Provider",
+    "variable": "Driving Time (min) to nearest Naltrexone Provider (state/county average)",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "NaltAvTmDr",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Driving Time (min) to nearest Naltrexone Provider (tract/ZIP)",
     "numerator": "zcta-2025__tract-2025",
     "nProperty": "NaltTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
-    "numerator": "zcta-2025__tract-2025",
-    "nProperty": "OtpTmDr",
+    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP) (state/county average)",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "OtpAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP)",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "OtpAvTmDr",
+    "variable": "Driving Time (min) to nearest Opioid Treatment Program (OTP) (tract/ZIP)",
+    "numerator": "zcta-2025__tract-2025",
+    "nProperty": "OtpTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
@@ -1428,14 +1414,14 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Pharmacies.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Substance Use Treatment program",
+    "variable": "Driving Time (min) to nearest Substance Use Treatment program (2020)",
     "numerator": "state-2020__county-2020",
     "nProperty": "SutpAvTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
   {
-    "variable": "Driving Time (min) to nearest Substance Use Treatment program",
+    "variable": "Driving Time (min) to nearest Substance Use Treatment program (2025)",
     "numerator": "state-2025__county-2025",
     "nProperty": "SutAvTmDr",
     "theme": "Environment",
@@ -2212,6 +2198,20 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Public_Expenditures.md"
   },
   {
+    "variable": "Population: Age 15-44 (count)",
+    "numerator": "state-2018__county-2018__zcta-2018__tract-2018",
+    "nProperty": "Age15_44",
+    "theme": "Social",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
+  },
+  {
+    "variable": "Population: Age 65+ (count)",
+    "numerator": "state-2023__county-2023__zcta-2023__tract-2023",
+    "nProperty": "Ovr65",
+    "theme": "Social",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Demographic_Characteristics.md"
+  },
+  {
     "variable": "Poverty %",
     "numerator": "state-2018__county-2023__zcta-2023__tract-2023",
     "nProperty": "PovP",
@@ -2877,16 +2877,16 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_Pharmacies.md"
   },
   {
-    "variable": "Tracts with Substance Use Treatment (SUT) program (30-min drive)",
-    "numerator": "state-2025__county-2025",
-    "nProperty": "SutCtTmDr",
+    "variable": "Tracts with Substance Use Treatment (SUT) program (30-min drive) (2020)",
+    "numerator": "state-2020__county-2020",
+    "nProperty": "SutpCtTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
   {
-    "variable": "Tracts with Substance Use Treatment (SUT) program (30-min drive)",
-    "numerator": "state-2020__county-2020",
-    "nProperty": "SutpCtTmDr",
+    "variable": "Tracts with Substance Use Treatment (SUT) program (30-min drive) (2025)",
+    "numerator": "state-2025__county-2025",
+    "nProperty": "SutCtTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_SubstanceUseTreatment.md"
   },
@@ -2989,42 +2989,42 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Housing_Variables.md"
   },
   {
-    "variable": "Walking Time (min) to Nearest Buprenorphine Provider",
+    "variable": "Walking Time (min) to nearest Buprenorphine Provider (state/county average)",
     "numerator": "county-2020",
     "nProperty": "BupAvTmWk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Walking Time (min) to Nearest Methadone Provide",
-    "numerator": "county-2020",
-    "nProperty": "MetAvTmWk",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Walking Time (min) to Nearest Naltrexone Provider",
-    "numerator": "county-2020",
-    "nProperty": "NaltAvTmWk",
-    "theme": "Environment",
-    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
-  },
-  {
-    "variable": "Walking Time (min) to nearest Buprenorphine Provider",
+    "variable": "Walking Time (min) to nearest Buprenorphine Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "BupTmWk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Walking Time (min) to nearest Methadone Provider",
+    "variable": "Walking Time (min) to nearest Methadone Provider (state/county average)",
+    "numerator": "county-2020",
+    "nProperty": "MetAvTmWk",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Walking Time (min) to nearest Methadone Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "MetTmWk",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
   },
   {
-    "variable": "Walking Time (min) to nearest Naltrexone Provider",
+    "variable": "Walking Time (min) to nearest Naltrexone Provider (state/county average)",
+    "numerator": "county-2020",
+    "nProperty": "NaltAvTmWk",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
+    "variable": "Walking Time (min) to nearest Naltrexone Provider (tract/ZIP)",
     "numerator": "county-2025__zcta-2020__tract-2025",
     "nProperty": "NaltTmWk",
     "theme": "Environment",


### PR DESCRIPTION
## Summary
Map search showed multiple variables under the same (or nearly the same) display title, making it easy to pick tract/ZIP driving-time variables when state/county averages were intended, or vice versa.

This PR updates registry `title` fields with consistent disambiguation suffixes, regenerates `explorer/config/variables.json`, and treats duplicate titles as a CI failure so they cannot regress.

## Changes
- **Registry titles (33 variables):** add suffixes such as `(tract/ZIP)`, `(state/county average)`, `(2025)` / `(2020)`, and `(count)` / `(percent)` for the duplicate pairs documented in #390
- **MOUD near-duplicates:** normalize `Nearest` → `nearest` and distinguish tract/ZIP vs state/county average for Methadone, Buprenorphine, and Naltrexone (driving, biking, walking)
- **Demographics:** `Age15_44` / `Ovr65` → count; `Age15_44P` / `Ovr65P` → percent
- **Explorer:** regenerate `explorer/config/variables.json` with updated search labels
- **CI:** `validate-registry` now runs with `--duplicate-titles-as-error`
- **Tests:** add `test_validate_fails_on_duplicate_titles`

## Not in scope
- Search dropdown UI changes (optional polish deferred)
- `explorer/config/sources.json` (no functional change; local hash churn only)

## Test plan
- [x] `flask validate-registry --strict` passes locally
- [ ] CI **Validate registry** workflow passes
- [x] On map search, verify disambiguated titles appear for:
  - [x] OTP: tract/ZIP vs state/county average
  - [x] Methadone / Buprenorphine / Naltrexone driving time
  - [x] SUT variables: 2025 vs 2020 pairs
  - [x] Age 15–44 and Age 65+ count vs percent
- [ ] Confirm selecting `(tract/ZIP)` variables enables **Tracts** / **Zip Codes**
- [ ] Confirm selecting `(state/county average)` variables enables **States** / **Counties**

Closes #390