### PR TITLE
Wire MoudTyp to tract-2025 for explorer map

### DIFF
--- a/backend/oeps/commands/validate_registry.py
+++ b/backend/oeps/commands/validate_registry.py
@@ -21,7 +21,10 @@ from ._common_opts import (
     "--check-columns",
     is_flag=True,
     default=False,
-    help="Fail if a variable table_sources entry has no matching column in that CSV.",
+    help=(
+        "Fail if table_sources miss CSV columns, or if table_sources is empty "
+        "but the variable name exists as a column in a CSV."
+    ),
 )
 @click.option(
     "--check-duplicate-titles",

--- a/backend/oeps/registry/variables/MoudTyp.json
+++ b/backend/oeps/registry/variables/MoudTyp.json
@@ -1,11 +1,13 @@
 {
   "name": "MoudTyp",
-  "title": "MOUD Types Within 30-Min Drive  (impedance, adjusted) ",
+  "title": "MOUD Types Within 30-Min Drive (impedance, adjusted)",
   "type": "integer",
   "example": "2",
-  "description": "Count (0\u00e2\u20ac\u201c3) of distinct MOUD provider types (buprenorphine, methadone, naltrexone) within a 30-minute impedance-adjusted driving time.",
+  "description": "Count (0-3) of distinct MOUD provider types (buprenorphine, methadone, naltrexone) within a 30-minute impedance-adjusted driving time.",
   "longitudinal": false,
   "analysis": true,
   "metadata": "Access_MOUDs",
-  "table_sources": []
+  "table_sources": [
+    "tract-2025"
+  ]
 }

--- a/backend/oeps/registry_validation.py
+++ b/backend/oeps/registry_validation.py
@@ -70,7 +70,12 @@ def validate_registry_structure(registry: Registry) -> ValidationResult:
 
 
 def validate_registry_csv_columns(registry: Registry) -> ValidationResult:
-    """Every table_sources entry must have the variable column in that CSV."""
+    """Check table_sources ↔ CSV column wiring both directions.
+
+    - Forward: every table_sources entry must have the variable column in that CSV.
+    - Reverse (empty links): if table_sources is empty but the variable name
+      appears as a column in any local CSV, fail (map will omit real data).
+    """
     result = ValidationResult()
     table_columns: dict[str, set[str]] = {}
 
@@ -90,6 +95,19 @@ def validate_registry_csv_columns(registry: Registry) -> ValidationResult:
                 result.errors.append(
                     f"{var_name} | column missing from {ts_name} CSV "
                     f"(listed in table_sources but not in file)"
+                )
+
+        if not variable.table_sources:
+            tables_with_col = sorted(
+                ts_name
+                for ts_name, cols in table_columns.items()
+                if var_name in cols
+            )
+            if tables_with_col:
+                result.errors.append(
+                    f"{var_name} | empty table_sources but column exists in "
+                    f"{', '.join(tables_with_col)}; link the table or remove "
+                    f"the orphan column"
                 )
 
     return result

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -105,6 +105,49 @@ def test_validate_fails_on_missing_csv_column(runner):
         bad_var.unlink(missing_ok=True)
 
 
+def test_validate_fails_on_empty_table_sources_with_csv_column(runner):
+    """CSV column exists but registry variable has empty table_sources (MoudTyp case)."""
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    csv_path = registry_path / "csv" / "t-latest.csv"
+    original_csv = csv_path.read_text(encoding="utf-8")
+    unlinked_var = registry_path / "variables" / "UnlinkedVar.json"
+    unlinked_var.write_text(
+        json.dumps(
+            {
+                "name": "UnlinkedVar",
+                "title": "Unlinked variable",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Demographic_Characteristics",
+                "table_sources": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    lines = original_csv.splitlines()
+    lines[0] = lines[0] + ",UnlinkedVar"
+    lines[1] = lines[1] + ",9"
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-columns",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "empty table_sources" in result.output.lower()
+        assert "unlinkedvar" in result.output.lower()
+    finally:
+        unlinked_var.unlink(missing_ok=True)
+        csv_path.write_text(original_csv, encoding="utf-8")
+
+
 def test_validate_fails_on_duplicate_titles(runner):
     registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
     dup_var = registry_path / "variables" / "DupTitleVar.json"

--- a/explorer/config/variables.json
+++ b/explorer/config/variables.json
@@ -1925,6 +1925,13 @@
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Housing_Variables.md"
   },
   {
+    "variable": "MOUD Types Within 30-Min Drive (impedance, adjusted)",
+    "numerator": "tract-2025",
+    "nProperty": "MoudTyp",
+    "theme": "Environment",
+    "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"
+  },
+  {
     "variable": "Mean yearly Hepatitis C deaths among Asian population from 2018-2022",
     "numerator": "state-2022",
     "nProperty": "AvAsHcvD",


### PR DESCRIPTION
## Summary
- Link `MoudTyp` to `tract-2025` so it appears on the explorer map (data was already in `tract-2025.csv` but `table_sources` was empty)
- Fix mojibake / title cleanup in `MoudTyp.json`
- Harden `validate-registry --check-columns` to fail when `table_sources` is empty but the variable name exists as a CSV column (prevents this class of map unlink)
- Add regression test; regenerate `explorer/config/variables.json`

Fixes #397

## Test plan
- [ ] `flask validate-registry --check-columns --check-geography-rules --check-duplicate-titles --duplicate-titles-as-error` passes
- [ ] `pytest backend/tests/test_registry.py` passes
- [ ] Confirm `MoudTyp` is in `explorer/config/variables.json` with `nProperty: "MoudTyp"` and `numerator: "tract-2025"`
- [ ] Local explorer: select tract 2025 and verify `MOUD Types Within 30-Min Drive (impedance, adjusted)` appears and maps

## Notes
Broader CSV-orphan / geography-rule generalization remains in #394. `HospAvTmDrP2` ghost stub left untouched (optional cleanup).
No workflow change needed: CI already runs `--check-columns`.