### PR TITLE
Generalize validate-registry geography rules

### DIFF
--- a/.github/workflows/validate_registry.yml
+++ b/.github/workflows/validate_registry.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'backend/oeps/registry/**'
       - 'backend/oeps/data/**'
+      - 'backend/oeps/registry/validation_allowlist.yaml'
       - '.github/workflows/validate_registry.yml'
   workflow_dispatch:
 
@@ -36,4 +37,4 @@ jobs:
         working-directory: backend
         env:
           FLASK_APP: oeps
-        run: flask validate-registry --check-columns --check-geography-rules --check-duplicate-titles --duplicate-titles-as-error
+        run: flask validate-registry --check-columns --check-csv-orphans --check-geography-rules --check-duplicate-titles --duplicate-titles-as-error

--- a/backend/oeps/commands/validate_registry.py
+++ b/backend/oeps/commands/validate_registry.py
@@ -42,13 +42,25 @@ from ._common_opts import (
     "--check-geography-rules",
     is_flag=True,
     default=False,
-    help="Enforce MOUD/access geography rules for table_sources.",
+    help="Enforce pattern-based geography rules for table_sources.",
+)
+@click.option(
+    "--check-csv-orphans",
+    is_flag=True,
+    default=False,
+    help="Warn when a registry variable column exists in a CSV but is not linked.",
+)
+@click.option(
+    "--csv-orphans-as-error",
+    is_flag=True,
+    default=False,
+    help="Treat CSV orphan column warnings as errors (use with --check-csv-orphans).",
 )
 @click.option(
     "--strict",
     is_flag=True,
     default=False,
-    help="Enable --check-columns, --check-duplicate-titles, and --check-geography-rules.",
+    help="Enable --check-columns, --check-csv-orphans, --check-duplicate-titles, and --check-geography-rules.",
 )
 def validate_registry(
     registry_path: Path,
@@ -57,12 +69,15 @@ def validate_registry(
     check_duplicate_titles: bool,
     duplicate_titles_as_error: bool,
     check_geography_rules: bool,
+    check_csv_orphans: bool,
+    csv_orphans_as_error: bool,
     strict: bool,
 ):
     """Runs validation processes against the current registry content."""
 
     if strict:
         check_columns = True
+        check_csv_orphans = True
         check_duplicate_titles = True
         check_geography_rules = True
 
@@ -77,7 +92,9 @@ def validate_registry(
             check_columns=check_columns,
             check_duplicate_titles=check_duplicate_titles,
             check_geography_rules=check_geography_rules,
+            check_csv_orphans=check_csv_orphans,
             duplicate_titles_as_error=duplicate_titles_as_error,
+            csv_orphans_as_error=csv_orphans_as_error,
         )
     except RegistryValidationError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/backend/oeps/handlers.py
+++ b/backend/oeps/handlers.py
@@ -245,9 +245,11 @@ class Registry(BaseModel):
         self,
         *,
         check_columns: bool = False,
+        check_csv_orphans: bool = False,
         check_duplicate_titles: bool = False,
         check_geography_rules: bool = False,
         duplicate_titles_as_error: bool = False,
+        csv_orphans_as_error: bool = False,
     ):
         from .registry_validation import (
             RegistryValidationError,
@@ -261,9 +263,11 @@ class Registry(BaseModel):
         result = run_registry_validation(
             self,
             check_columns=check_columns,
+            check_csv_orphans=check_csv_orphans,
             check_duplicate_titles=check_duplicate_titles,
             check_geography_rules=check_geography_rules,
             duplicate_titles_as_error=duplicate_titles_as_error,
+            csv_orphans_as_error=csv_orphans_as_error,
         )
         print_validation_result(result)
 

--- a/backend/oeps/registry/validation_allowlist.yaml
+++ b/backend/oeps/registry/validation_allowlist.yaml
@@ -1,0 +1,18 @@
+# Exceptions to generic registry validation rules.
+# Prefer fixing registry/CSV data; use this only when an exception is intentional.
+
+geography_table_sources: []
+
+csv_orphan_columns:
+  - variable: TlBupTmDr
+    table_source: county-2025
+    reason: Stale county column after registry unlink (pending CSV cleanup).
+  - variable: MetTmDr
+    table_source: county-2025
+    reason: Stale county column; registry no longer links county (pending CSV cleanup).
+  - variable: BupTmDr
+    table_source: county-2025
+    reason: Stale county column; registry no longer links county (pending CSV cleanup).
+  - variable: NaltTmDr
+    table_source: county-2025
+    reason: Stale county column; registry no longer links county (pending CSV cleanup).

--- a/backend/oeps/registry/variables/TlBupTmDr.json
+++ b/backend/oeps/registry/variables/TlBupTmDr.json
@@ -8,7 +8,6 @@
   "analysis": false,
   "metadata": "Access_MOUDs",
   "table_sources": [
-    "county-2025",
     "tract-2025"
   ]
 }

--- a/backend/oeps/registry_validation.py
+++ b/backend/oeps/registry_validation.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 if TYPE_CHECKING:
     from .handlers import Registry
 
-POINT_TMDR_VARIABLES = frozenset({"MetTmDr", "BupTmDr", "NaltTmDr", "OtpTmDr"})
-IMPEDANCE_TMDR_VARIABLES = frozenset({"MetTmDr2", "BupTmDr2", "NaltTmDr2", "OtpTmDr2"})
-IMPEDANCE_TRACT_TABLE = "tract-2025"
+_REGISTRY_DIR = Path(__file__).resolve().parent / "registry"
+_DEFAULT_ALLOWLIST_PATH = _REGISTRY_DIR / "validation_allowlist.yaml"
+_SKIP_CSV_COLUMNS = frozenset({"HEROP_ID", "FIPS", "ZCTA5", "Name"})
+
 
 class RegistryValidationError(Exception):
     """Raised when registry validation fails."""
@@ -28,6 +31,73 @@ class ValidationResult:
         return not self.errors
 
 
+@dataclass(frozen=True)
+class ValidationAllowlist:
+    geography_table_sources: frozenset[tuple[str, str]]
+    csv_orphan_columns: frozenset[tuple[str, str]]
+
+
+def _load_allowlist(path: Path | None = None) -> ValidationAllowlist:
+    allowlist_path = path or _DEFAULT_ALLOWLIST_PATH
+    if not allowlist_path.is_file():
+        return ValidationAllowlist(
+            geography_table_sources=frozenset(),
+            csv_orphan_columns=frozenset(),
+        )
+
+    raw = yaml.safe_load(allowlist_path.read_text(encoding="utf-8")) or {}
+    geography = frozenset(
+        (entry["variable"], entry["table_source"])
+        for entry in raw.get("geography_table_sources", [])
+        if entry.get("variable") and entry.get("table_source")
+    )
+    csv_orphans = frozenset(
+        (entry["variable"], entry["table_source"])
+        for entry in raw.get("csv_orphan_columns", [])
+        if entry.get("variable") and entry.get("table_source")
+    )
+    return ValidationAllowlist(
+        geography_table_sources=geography,
+        csv_orphan_columns=csv_orphans,
+    )
+
+
+def is_point_tmdr(var_name: str) -> bool:
+    """Point-to-point driving time (*TmDr), not rollup/average/impedance variants."""
+    if "TmDr" not in var_name:
+        return False
+    if "AvTmDr" in var_name:
+        return False
+    if "TmDrP" in var_name:
+        return False
+    if "CtTmDr" in var_name:
+        return False
+    if "TmDr2" in var_name:
+        return False
+    return True
+
+
+def is_impedance_point_tmdr(var_name: str) -> bool:
+    """Impedance-adjusted point driving time (*TmDr2), not rollup/average variants."""
+    if "TmDr2" not in var_name:
+        return False
+    if "AvTmDr" in var_name:
+        return False
+    if "CtTmDr" in var_name:
+        return False
+    if "TmDrP" in var_name:
+        return False
+    return True
+
+
+def is_rollup_tmdr(var_name: str) -> bool:
+    return "TmDrP" in var_name or "CtTmDr" in var_name
+
+
+def is_average_tmdr(var_name: str) -> bool:
+    return "AvTmDr" in var_name
+
+
 def _table_summary_level(registry: Registry, table_source_name: str) -> str | None:
     ts = registry.table_sources.get(table_source_name)
     if not ts:
@@ -40,6 +110,19 @@ def _table_summary_level(registry: Registry, table_source_name: str) -> str | No
 
 def _is_remote_table_path(path: str) -> bool:
     return path.startswith("http://") or path.startswith("https://")
+
+
+def _load_table_columns(registry: Registry) -> dict[str, set[str]]:
+    table_columns: dict[str, set[str]] = {}
+    for ts_name, ts in registry.table_sources.items():
+        if _is_remote_table_path(ts.full_path):
+            continue
+        pathpath = Path(ts.full_path)
+        if not pathpath.is_file():
+            continue
+        ts.load_dataframe()
+        table_columns[ts_name] = set(ts.df.columns)
+    return table_columns
 
 
 def validate_registry_structure(registry: Registry) -> ValidationResult:
@@ -77,14 +160,7 @@ def validate_registry_csv_columns(registry: Registry) -> ValidationResult:
       appears as a column in any local CSV, fail (map will omit real data).
     """
     result = ValidationResult()
-    table_columns: dict[str, set[str]] = {}
-
-    for ts_name, ts in registry.table_sources.items():
-        pathpath = Path(ts.full_path)
-        if not pathpath.is_file():
-            continue
-        ts.load_dataframe()
-        table_columns[ts_name] = set(ts.df.columns)
+    table_columns = _load_table_columns(registry)
 
     for var_name, variable in registry.variables.items():
         for ts_name in variable.table_sources:
@@ -113,6 +189,35 @@ def validate_registry_csv_columns(registry: Registry) -> ValidationResult:
     return result
 
 
+def validate_registry_csv_orphans(
+    registry: Registry,
+    *,
+    allowlist: ValidationAllowlist | None = None,
+) -> ValidationResult:
+    """Warn when a registry variable column exists in a CSV but is not linked."""
+    result = ValidationResult()
+    allowlist = allowlist or _load_allowlist()
+    table_columns = _load_table_columns(registry)
+
+    for ts_name, cols in table_columns.items():
+        for col in cols:
+            if col in _SKIP_CSV_COLUMNS:
+                continue
+            if col not in registry.variables:
+                continue
+            variable = registry.variables[col]
+            if ts_name in variable.table_sources:
+                continue
+            if (col, ts_name) in allowlist.csv_orphan_columns:
+                continue
+            result.warnings.append(
+                f"{col} | column in {ts_name} CSV but not in table_sources "
+                f"(orphan column; link registry or remove from CSV)"
+            )
+
+    return result
+
+
 def validate_duplicate_titles(registry: Registry) -> ValidationResult:
     """Warn when multiple variables share the same display title."""
     result = ValidationResult()
@@ -129,48 +234,53 @@ def validate_duplicate_titles(registry: Registry) -> ValidationResult:
     return result
 
 
-def validate_geography_rules(registry: Registry) -> ValidationResult:
-    """MOUD/access geography rules from issue #391."""
+def validate_geography_rules(
+    registry: Registry,
+    *,
+    allowlist: ValidationAllowlist | None = None,
+) -> ValidationResult:
+    """Pattern-based geography rules for access/driving-time variables."""
     result = ValidationResult()
-    tract_cols: set[str] | None = None
-    tract_ts = registry.table_sources.get(IMPEDANCE_TRACT_TABLE)
-    if tract_ts and Path(tract_ts.full_path).is_file():
-        tract_ts.load_dataframe()
-        tract_cols = set(tract_ts.df.columns)
+    allowlist = allowlist or _load_allowlist()
+    table_columns = _load_table_columns(registry)
 
     for var_name, variable in registry.variables.items():
-        if (
-            var_name in IMPEDANCE_TMDR_VARIABLES
-            and tract_cols is not None
-            and var_name in tract_cols
-            and IMPEDANCE_TRACT_TABLE not in variable.table_sources
-        ):
-            result.errors.append(
-                f"{var_name} | column exists in {IMPEDANCE_TRACT_TABLE} but "
-                f"{IMPEDANCE_TRACT_TABLE} is not in table_sources"
-            )
+        if is_impedance_point_tmdr(var_name):
+            for ts_name, cols in table_columns.items():
+                if _table_summary_level(registry, ts_name) != "tract":
+                    continue
+                if var_name not in cols:
+                    continue
+                if ts_name in variable.table_sources:
+                    continue
+                if (var_name, ts_name) in allowlist.geography_table_sources:
+                    continue
+                result.errors.append(
+                    f"{var_name} | column exists in {ts_name} but "
+                    f"{ts_name} is not in table_sources"
+                )
 
         for ts_name in variable.table_sources:
             level = _table_summary_level(registry, ts_name)
             if not level:
                 continue
 
-            if var_name in POINT_TMDR_VARIABLES and level in {"state", "county"}:
+            if (var_name, ts_name) in allowlist.geography_table_sources:
+                continue
+
+            if is_point_tmdr(var_name) and level in {"state", "county"}:
                 result.errors.append(
                     f"{var_name} | point-to-point driving time must not use "
                     f"{ts_name} ({level} level); remove from table_sources"
                 )
 
-            if any(
-                marker in var_name
-                for marker in ("TmDrP", "CtTmDr")
-            ) and level in {"tract", "zcta"}:
+            if is_rollup_tmdr(var_name) and level in {"tract", "zcta"}:
                 result.errors.append(
                     f"{var_name} | rollup variable must not use "
                     f"{ts_name} ({level} level)"
                 )
 
-            if "AvTmDr" in var_name and level in {"tract", "zcta"}:
+            if is_average_tmdr(var_name) and level in {"tract", "zcta"}:
                 result.errors.append(
                     f"{var_name} | average driving time must not use "
                     f"{ts_name} ({level} level)"
@@ -183,10 +293,14 @@ def run_registry_validation(
     registry: Registry,
     *,
     check_columns: bool = False,
+    check_csv_orphans: bool = False,
     check_duplicate_titles: bool = False,
     check_geography_rules: bool = False,
     duplicate_titles_as_error: bool = False,
+    csv_orphans_as_error: bool = False,
+    allowlist_path: Path | None = None,
 ) -> ValidationResult:
+    allowlist = _load_allowlist(allowlist_path)
     combined = ValidationResult()
 
     for partial in (
@@ -200,6 +314,13 @@ def run_registry_validation(
         combined.errors.extend(partial.errors)
         combined.warnings.extend(partial.warnings)
 
+    if check_csv_orphans:
+        partial = validate_registry_csv_orphans(registry, allowlist=allowlist)
+        if csv_orphans_as_error:
+            combined.errors.extend(partial.warnings)
+            partial.warnings = []
+        combined.warnings.extend(partial.warnings)
+
     if check_duplicate_titles:
         partial = validate_duplicate_titles(registry)
         if duplicate_titles_as_error:
@@ -208,7 +329,7 @@ def run_registry_validation(
         combined.warnings.extend(partial.warnings)
 
     if check_geography_rules:
-        partial = validate_geography_rules(registry)
+        partial = validate_geography_rules(registry, allowlist=allowlist)
         combined.errors.extend(partial.errors)
         combined.warnings.extend(partial.warnings)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'python-dotenv',
     'natsort',
     'pydantic',
+    'PyYAML',
 ]
 
 

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -183,6 +183,113 @@ def test_validate_fails_on_duplicate_titles(runner):
         dup_var.unlink(missing_ok=True)
 
 
+def test_validate_geography_rules_generic_point_tmdr(runner):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    bad_var = registry_path / "variables" / "BadPointTmDr.json"
+    bad_var.write_text(
+        json.dumps(
+            {
+                "name": "BadPointTmDr",
+                "title": "Bad point driving time",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Demographic_Characteristics",
+                "table_sources": ["c-2010"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-geography-rules",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "badpointtmdr" in result.output.lower()
+    finally:
+        bad_var.unlink(missing_ok=True)
+
+
+def test_validate_geography_rules_impedance_tmdr2_missing_tract(runner):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    bad_var = registry_path / "variables" / "BadTmDr2.json"
+    bad_var.write_text(
+        json.dumps(
+            {
+                "name": "BadTmDr2",
+                "title": "Bad impedance driving time",
+                "type": "number",
+                "example": "1",
+                "description": "test",
+                "longitudinal": False,
+                "analysis": False,
+                "metadata": "Demographic_Characteristics",
+                "table_sources": ["c-2010"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        result = runner.invoke(
+            args=[
+                "validate-registry",
+                "--registry-path",
+                str(registry_path),
+                "--check-geography-rules",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "badtmdr2" in result.output.lower()
+    finally:
+        bad_var.unlink(missing_ok=True)
+
+
+def test_validate_csv_orphans_warns(runner):
+    registry_path = Path(runner.app.config["TEST_REGISTRY_DIR"])
+    result = runner.invoke(
+        args=[
+            "validate-registry",
+            "--registry-path",
+            str(registry_path),
+            "--check-csv-orphans",
+        ]
+    )
+    assert result.exit_code == 0
+    assert "mettmdr" in result.output.lower()
+    assert "warning" in result.output.lower()
+
+
+def test_pattern_helpers():
+    from oeps.registry_validation import (
+        is_average_tmdr,
+        is_impedance_point_tmdr,
+        is_point_tmdr,
+        is_rollup_tmdr,
+    )
+
+    assert is_point_tmdr("MetTmDr")
+    assert is_point_tmdr("TlBupTmDr")
+    assert not is_point_tmdr("MetAvTmDr")
+    assert not is_point_tmdr("MetTmDrP")
+    assert not is_point_tmdr("MetCtTmDr")
+    assert not is_point_tmdr("MetTmDr2")
+
+    assert is_impedance_point_tmdr("MetTmDr2")
+    assert not is_impedance_point_tmdr("MetCtTmDr2")
+    assert not is_impedance_point_tmdr("MetAvTmDr2")
+
+    assert is_rollup_tmdr("MetTmDrP")
+    assert is_rollup_tmdr("MetCtTmDr")
+    assert is_average_tmdr("MetAvTmDr")
+
+
 def test_registry_validation_error_is_raised():
     from oeps.handlers import Registry
 

--- a/backend/tests/test_registry/csv/c-2010.csv
+++ b/backend/tests/test_registry/csv/c-2010.csv
@@ -1,2 +1,2 @@
-HEROP_ID,TotPop
+HEROP_ID,TotPop,MetTmDr
 1,100

--- a/backend/tests/test_registry/csv/t-latest.csv
+++ b/backend/tests/test_registry/csv/t-latest.csv
@@ -1,2 +1,2 @@
-HEROP_ID,TotPop,MetTmDr
-1,100,10
+HEROP_ID,TotPop,MetTmDr,BadTmDr2
+1,100,10,5

--- a/explorer/config/variables.json
+++ b/explorer/config/variables.json
@@ -1583,7 +1583,7 @@
   },
   {
     "variable": "Driving time to nearest telehealth buprenorphine provider",
-    "numerator": "county-2025__tract-2025",
+    "numerator": "tract-2025",
     "nProperty": "TlBupTmDr",
     "theme": "Environment",
     "metadataUrl": "https://github.com/healthyregions/oeps/blob/main/metadata/Access_MOUDs.md"


### PR DESCRIPTION
## Summary
- Replace hardcoded MOUD geography frozensets with pattern-based helpers (`is_point_tmdr`, `is_impedance_point_tmdr`, etc.)
- Add reverse CSV → registry orphan check (`--check-csv-orphans`) with `validation_allowlist.yaml` for known stale county columns
- Unlink `TlBupTmDr` from `county-2025` (tract-only) and update explorer config
- Enable `--check-csv-orphans` in CI while keeping `--duplicate-titles-as-error`
- Add tests for generic geography rules, orphans, and pattern helpers

Fixes #394

## Test plan
- [ ] `flask validate-registry --check-columns --check-csv-orphans --check-geography-rules --check-duplicate-titles --duplicate-titles-as-error` passes
- [ ] `pytest backend/tests/test_registry.py` passes
- [ ] Confirm CI Validate registry workflow runs the flags above
- [ ] Spot-check map: `TlBupTmDr` is tract-only; `MoudTyp` still on map from #398

## Notes
- Stale county CSV columns (`MetTmDr` / `BupTmDr` / `NaltTmDr` / `TlBupTmDr` on `county-2025`) are allowlisted as intentional warnings pending CSV cleanup
- Empty-`table_sources` guard from #398 is preserved alongside the new orphan check