### PR TITLE
fix: broken link on Data Access page (fixes #404)

### DIFF
--- a/explorer/pages/download.js
+++ b/explorer/pages/download.js
@@ -111,7 +111,7 @@ export default function Download() {
 // //      if (activeFilters.year.length !== 0 && !activeFilters.year.includes('Geographic Boundaries')){
 // //        geomsToDownload = []
 // //      }
-      
+
 //       if (activeFilters.scale.length){
 //         geomsToDownload = geomsToDownload.filter(f => activeFilters.scale.includes(f.agg))
 //       }
@@ -224,9 +224,9 @@ export default function Download() {
             <h3 id="csv-downloads">All data by year</h3>
               <p>Looking for historical data, or years outside of what is included in the data packages above? Use the individual CSVs listed below to find what you need. CSVs are grouped by geography (<Link href="#state-csvs">state</Link>, <Link href="#county-csvs">county</Link>, <Link href="#tract-csvs">tract</Link>, <Link href="#zcta-csvs">zcta</Link>), and tend to be consolidated one-per-year. However, you may see some exceptions to this where data from the same year must be joined to different <Link href="#geography-files">geography files</Link>.</p>
               <p>We have generated a data dictionary for each geography level that summarizes what variables and which years are available.</p>
-              
+
               <p> <b> Caution!!</b> Some data are multi-year averages. They will be included in the final year of release,
-              for example: the Social Vulnerability Index from 2018 actually includes Census data from five years (2013-2018). 
+              for example: the Social Vulnerability Index from 2018 actually includes Census data from five years (2013-2018).
               In social science & demographcis research, using multi-year averages often provide the most stable data results,
                with final data corresponding to actual phenomena and not measurement errors. We strongly recommend
               using Data Suite Packages that have been carefully curated for your research needs!</p>
@@ -242,7 +242,7 @@ export default function Download() {
                       <th>File</th>
                       <th>Join to</th>
                     </tr>
-                    {csvDownloads.state.map(row => 
+                    {csvDownloads.state.map(row =>
                     <tr key={row.name}>
                         <td>{row.year}</td>
                         <td><Link href={row.url}>{row.name}</Link></td>
@@ -263,7 +263,7 @@ export default function Download() {
                       <th>File</th>
                       <th>Join to</th>
                     </tr>
-                    {csvDownloads.county.map(row => 
+                    {csvDownloads.county.map(row =>
                     <tr key={row.name}>
                         <td>{row.year}</td>
                         <td><Link href={row.url}>{row.name}</Link></td>
@@ -284,7 +284,7 @@ export default function Download() {
                       <th>File</th>
                       <th>Join to</th>
                     </tr>
-                    {csvDownloads.tract.map(row => 
+                    {csvDownloads.tract.map(row =>
                     <tr key={row.name}>
                         <td>{row.year}</td>
                         <td><Link href={row.url}>{row.name}</Link></td>
@@ -305,7 +305,7 @@ export default function Download() {
                       <th>File</th>
                       <th>Join to</th>
                     </tr>
-                    {csvDownloads.zcta.map(row => 
+                    {csvDownloads.zcta.map(row =>
                     <tr key={row.name}>
                         <td>{row.year}</td>
                         <td><Link href={row.url}>{row.name}</Link></td>
@@ -325,7 +325,7 @@ export default function Download() {
                     <th>Id</th>
                     <th>Download links</th>
                   </tr>
-                  {geodataDownloads.map(row => 
+                  {geodataDownloads.map(row =>
                   <tr key={row.name}>
                       <td>{row.name}</td>
                       <td>
@@ -354,8 +354,8 @@ export default function Download() {
           </div>
           <div className="col-xs-12 col-md-8 col-lg-9">
             <h3 id="oeps-data-package"><Link href="https://oepsdata.healthyregions.org">oepsData &mdash; R Package</Link></h3>
-              <p>We maintain a small R package called <Link href="https://oepsdata.healthyregions.org">oepsData</Link>. 
-              We currently only include data from 2021 and prior (corresponding to 2018/2010 Census Vintage) at this time, with an updated planned 
+              <p>We maintain a small R package called <Link href="https://oepsdata.healthyregions.org">oepsData</Link>.
+              We currently only include data from 2021 and prior (corresponding to 2018/2010 Census Vintage) at this time, with an updated planned
               in the next year. This package is the best way for researchers who use R to load and analyze OEPS data directly, without the need to download CSVs or Shapefiles and worry about joins.</p>
               <ul>
                 <li><Link href="https://oepsdata.healthyregions.org">Documentation</Link>: Learn how to install and use the package.</li>
@@ -368,12 +368,10 @@ export default function Download() {
               <ul>
                 <li><Link href="https://oepsdata.healthyregions.org/getting-oeps-data-from-bigquery.html">Introduction to OEPS in Google BigQuery</Link>: The oepsData documentation includes a detailed overview that is relevant no matter what client you use.</li>
                 <li><Link href="https://oepsdata.healthyregions.org/getting-oeps-data-from-bigquery.html#setting-up-bigquery">Setting up BigQuery in R</Link>: The oepsData documentation also has a walkthrough guide illustrating how R users can connect directly to our data in BigQuery.</li>
+                <li><Link href="https://github.com/healthyregions/oeps/blob/main/docs/src/reference/bigquery/tables.md">Database Table Reference</Link>: Full reference document, provides the project id and the names of all tables and columns.</li>
               </ul>
           </div>
         </div>
-
-        {/*  <li><Link href="https://github.com/healthyregions/oeps/blob/main/docs/src/reference/bigquery/tables.md">Database Table Reference</Link>: Full reference document, provides the project id and the names of all tables and columns.</li>
-
 
          <Gutter em={5} />
 
@@ -398,7 +396,7 @@ export default function Download() {
             </div>}
         </div> : null}
         <button className={`${downloadMessage.length !== 0 ? styles.passiveButton : ''} ${styles.downloadButton}`} onClick={handleDownload} disabled={downloadMessage.length !== 0}>Download Selected Data</button> */}
-        
+
       </main>
       <Footer />
     </div>

--- a/explorer/pages/download.js
+++ b/explorer/pages/download.js
@@ -372,7 +372,7 @@ export default function Download() {
           </div>
         </div>
 
-        {/*  <li><Link href="https://github.com/healthyregions/oeps/blob/main/docs/reference/big-query-tables.md">Database Table Reference</Link>: Full reference document, provides the project id and the names of all tables and columns.</li>
+        {/*  <li><Link href="https://github.com/healthyregions/oeps/blob/main/docs/src/reference/bigquery/tables.md">Database Table Reference</Link>: Full reference document, provides the project id and the names of all tables and columns.</li>
 
 
          <Gutter em={5} />

--- a/explorer/pages/download.js
+++ b/explorer/pages/download.js
@@ -373,7 +373,9 @@ export default function Download() {
           </div>
         </div>
 
-         <Gutter em={5} />
+        {/*
+        
+        <Gutter em={5} />
 
         <h2>Filter Data and Download</h2>
 
@@ -395,7 +397,9 @@ export default function Download() {
               <span className={styles.progressBar} style={{width: `${zipPct}%`}}/>
             </div>}
         </div> : null}
-        <button className={`${downloadMessage.length !== 0 ? styles.passiveButton : ''} ${styles.downloadButton}`} onClick={handleDownload} disabled={downloadMessage.length !== 0}>Download Selected Data</button> */}
+        <button className={`${downloadMessage.length !== 0 ? styles.passiveButton : ''} ${styles.downloadButton}`} onClick={handleDownload} disabled={downloadMessage.length !== 0}>Download Selected Data</button>
+
+        */}
 
       </main>
       <Footer />


### PR DESCRIPTION
## Problem
The link to "Data Table Reference" is broken on the Data Access / Download page

Fixes #404 

## Approach
* fix: [these docs](https://github.com/healthyregions/oeps/blob/main/docs/src/reference/bigquery/tables.md) have moved - update the link to point to the correct location in the `docs` folders

## How to Test
1. Navigate to https://deploy-preview-412--oeps.netlify.app/download
2. Scroll all the way down to the bottom of the page
    * You should see 3 links listed at the bottom of the page
3. Click on the link labeled "Data Table Reference"
    * You should be brought to GitHub where you can view the docs
    * You should **NOT** see a 404 error here anymore