### PR TITLE
fix: point DSuite2023 download at stable S3 zip

### DIFF
--- a/explorer/pages/download.js
+++ b/explorer/pages/download.js
@@ -218,7 +218,7 @@ export default function Download() {
                 <Link href="https://github.com/healthyregions/oeps/raw/refs/heads/main/docs/src/reference/data-dictionaries/DSuite2023-data-dictionary.xlsx">Download DSuite2023 data dictionary</Link>
               </li>
               <li>
-                <Link href="https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2023_no_foreign_keys.zip">Download DSuite2023 data package (100mb+)</Link>
+                <Link href="https://herop-geodata.s3.us-east-2.amazonaws.com/oeps/oeps-DSuite2023.zip">Download DSuite2023 data package (100mb+)</Link>
               </li>
             </ul>
             <h3 id="csv-downloads">All data by year</h3>


### PR DESCRIPTION
Update the Data Access link to oeps-DSuite2023.zip after rebuilding the package on S3 (refs #387).